### PR TITLE
Fix regular expression for jumping to Function/FunctionBody code

### DIFF
--- a/M2.el
+++ b/M2.el
@@ -306,11 +306,11 @@ can be executed with \\[M2-send-to-program]."
   interpreter using \\[comint-send-input]."
   (interactive)
   (cond ((save-excursion
-	   (search-backward-regexp "\\({\\*\\|^\\)")
-	   ;; example: {*FunctionBody[../../d/startup.m2.in:123:19-123:21]*}
-	   ;; example: {*Function[../../m2/res.m2:191:40-202:36]*}
+	   (search-backward-regexp "\\(-\\*\\|^\\)")
+	   ;; example: -*FunctionBody[../../d/startup.m2.in:123:19-123:21]*-
+	   ;; example: -*Function[../../m2/res.m2:191:40-202:36]*-
 	   ;;                         (1    1)      (2       2)   (3      3)   (4      4)   (5      5)   (6      6)
-	   (looking-at "{\\*Function\\(Body\\)?\\[\\([^:\n]+\\):\\([0-9]+\\):\\([0-9]+\\)-\\([0-9]+\\):\\([0-9]+\\)\\]\\*}"))
+	   (looking-at "-\\*Function\\(Body\\)?\\[\\([^:\n]+\\):\\([0-9]+\\):\\([0-9]+\\)-\\([0-9]+\\):\\([0-9]+\\)\\]\\*-"))
 	 (let ((filename (buffer-substring (match-beginning 2) (match-end 2)))
 	       (linenum (string-to-number (buffer-substring (match-beginning 3) (match-end 3))))
 	       (colnum (if (match-beginning 4) (string-to-number (buffer-substring (match-beginning 4) (match-end 4))) 1))


### PR DESCRIPTION
It was still expecting the deprecated {* ... *} comment style.