### PR TITLE
Set indent-line-function instead of defining TAB behavior directly

### DIFF
--- a/M2.el
+++ b/M2.el
@@ -67,6 +67,7 @@
   (set (make-local-variable 'comment-start-skip) "-- *")
   (set (make-local-variable 'comint-input-autoexpand) nil)
   (set (make-local-variable 'transient-mark-mode) t)
+  (set (make-local-variable 'indent-line-function) 'M2-electric-tab)
   (setq font-lock-defaults '( M2-mode-font-lock-keywords ))
   (setq truncate-lines t)
   (setq case-fold-search nil))
@@ -75,7 +76,6 @@
 
 (define-key M2-mode-map "\177" 'backward-delete-char-untabify)
 (define-key M2-mode-map "\^M" 'M2-newline-and-indent)
-(define-key M2-mode-map "\t" 'M2-electric-tab)
 ;; (define-key M2-mode-map "}" 'M2-electric-right-brace)
 (define-key M2-mode-map ";" 'M2-electric-semi)
 ;; (define-key M2-mode-map "\^Cd" 'M2-find-documentation)


### PR DESCRIPTION
This lets us take advantage of various built-in indentation features.
In particular, `M-x indent-region` (or `C-M \`) works to indent an
entire region.