### PR TITLE
Newline and indent updates

### DIFF
--- a/M2.el
+++ b/M2.el
@@ -505,7 +505,7 @@ be sent can be entered, with history."
      (interactive)
      (insert ?\;)
      (and (eolp) (M2-next-line-blank) (= 0 (M2-paren-change))
-	 (M2-newline-and-indent)))
+	 (newline nil t)))
 
 (defun M2-next-line-indent-amount ()
      (+ (current-indentation) (* (M2-paren-change) M2-indent-level)))

--- a/M2.el
+++ b/M2.el
@@ -543,17 +543,12 @@ be sent can be entered, with history."
 
 (defun M2-electric-tab ()
      (interactive)
-     (if (or (not (M2-in-front)) (M2-blank-line))
-	 (indent-to (+ (current-column) M2-indent-level))
-	 (let ((i (M2-this-line-indent-amount))
-	       (j (current-indentation)))
-	      (if (not (= i j))
-		  (progn
-		       (if (< i j)
-			    (delete-region (progn (beginning-of-line) (point))
-					   (progn (back-to-indentation) (point)))
-			    (back-to-indentation))
-		       (indent-to i))))))
+     (save-excursion
+       (delete-region (progn (beginning-of-line) (point))
+		      (progn (back-to-indentation) (point)))
+       (indent-to (M2-this-line-indent-amount)))
+     (if (< (current-column) (current-indentation))
+	 (back-to-indentation)))
 
 (defvar M2-demo-buffer
   (save-excursion

--- a/M2.el
+++ b/M2.el
@@ -540,7 +540,7 @@ be sent can be entered, with history."
 (defun M2-electric-right-brace()
      (interactive)
      (self-insert-command 1)
-     (and (eolp) (M2-next-line-blank) (< (M2-paren-change) 0) (M2-newline-and-indent)))
+     (and (eolp) (M2-next-line-blank) (< (M2-paren-change) 0) (newline nil t)))
 
 (defun M2-electric-tab ()
      (interactive)

--- a/M2.el
+++ b/M2.el
@@ -75,7 +75,6 @@
 ;; key bindings
 
 (define-key M2-mode-map "\177" 'backward-delete-char-untabify)
-(define-key M2-mode-map "\^M" 'M2-newline-and-indent)
 ;; (define-key M2-mode-map "}" 'M2-electric-right-brace)
 (define-key M2-mode-map ";" 'M2-electric-semi)
 ;; (define-key M2-mode-map "\^Cd" 'M2-find-documentation)

--- a/M2.el
+++ b/M2.el
@@ -532,6 +532,7 @@ be sent can be entered, with history."
 
 (defun M2-newline-and-indent ()
      "Start a new line and indent it properly for Macaulay2 code."
+     (declare (obsolete newline "Macaulay2 1.18"))
      (interactive)
      (newline)
      (indent-to (M2-this-line-indent-amount)))


### PR DESCRIPTION
It is currently bound to `M2-newline-and-indent`, which calls
`newline` and then indents.  However, `newline` by itself already
indents the next line (provided that the user has
`electric-indent-mode` enabled, which is the default), and so calling
this specialized function is unnecessary.  Furthermore, C-m is already
bound to `newline` in `global-map`, so there's no reason to bind it
again.

Also, if the user has turned off `electric-indent-mode`, then C-m will
have the desired behavior -- no electric indents.