### PR TITLE
Add SimpleDoc major mode

### DIFF
--- a/M2-init.el
+++ b/M2-init.el
@@ -3,6 +3,7 @@
 (autoload 'M2             "M2" "Run Macaulay2 in an emacs buffer" t)
 (autoload 'M2-mode        "M2" "Macaulay2 editing mode" t)
 (autoload 'M2-comint-mode "M2" "Macaulay2 command interpreter mode" t)
+(autoload 'M2-simple-doc-mode "M2" "Macaulay2 SimpleDoc editing mode" t)
 (add-to-list 'auto-mode-alist '("\\.m2\\'" . M2-mode))
 
 ;; Uncomment these lines to enable syntax highlighting for the interpreter language

--- a/M2.el
+++ b/M2.el
@@ -542,14 +542,17 @@ be sent can be entered, with history."
      (self-insert-command 1)
      (and (eolp) (M2-next-line-blank) (< (M2-paren-change) 0) (newline nil t)))
 
+(defun M2-indent-to (indent-amount)
+  (save-excursion
+    (delete-region (progn (beginning-of-line) (point))
+		   (progn (back-to-indentation) (point)))
+    (indent-to indent-amount))
+  (if (< (current-column) (current-indentation))
+      (back-to-indentation)))
+
 (defun M2-electric-tab ()
-     (interactive)
-     (save-excursion
-       (delete-region (progn (beginning-of-line) (point))
-		      (progn (back-to-indentation) (point)))
-       (indent-to (M2-this-line-indent-amount)))
-     (if (< (current-column) (current-indentation))
-	 (back-to-indentation)))
+  (interactive)
+  (M2-indent-to (M2-this-line-indent-amount)))
 
 (defvar M2-demo-buffer
   (save-excursion


### PR DESCRIPTION
The new indent/newline behavior I introduced in #18 totally broke writing `SimpleDoc` documentation.  Since it doesn't use parentheses, everything is automatically flushed to the far left:

```m2
doc ///
Key
foo
Description
Text
foo
///
```
Of course, users can still get around this by turning off `electric-indent-mode`, or just using `C-j` for newlines, but I figured taking a stab at tackling #13 would be nice.

This PR is a first draft a new major mode, `M2-simple-doc-mode`.  It's derived from `M2-mode` and only defines a new `indent-line-function`.  Users can toggle between the two with `M2-toggle-simple-doc-mode` (currently bound to `C-c C-s`, but I'm open to suggestions!)  With this mode enabled, tabbing works as expected:

```m2
doc ///
  Key
    foo
  Description
    Text
      foo
///
```
It's not perfect yet (`Inputs`, `Outputs`, and `CannedExample` don't quite work yet), but it's certainly better than the current behavior!