### PR TITLE
Use make-frame in M2-demo instead of new-frame

### DIFF
--- a/M2.el
+++ b/M2.el
@@ -455,7 +455,7 @@ be sent can be entered, with history."
   (interactive)
   (let* ((f (prog1
 	      (select-frame
-	       (new-frame
+	       (make-frame
 		'((height . 30)
 		  (width . 80)
 		  (menu-bar-lines . 0)


### PR DESCRIPTION
`new-frame` was [made obsolete](https://git.savannah.gnu.org/cgit/emacs.git/commit/lisp/frame.el?id=f7df88f) in Emacs 22 and [removed](https://git.savannah.gnu.org/cgit/emacs.git/commit/lisp/frame.el?id=f1c48b0) in Emacs 27.