### PR TITLE
Add menus to M2-mode and M2-comint-mode

### DIFF
--- a/M2.el
+++ b/M2.el
@@ -110,6 +110,41 @@
     (define-key mode-map [ (meta f10) ] 'M2-match-previous-bracketed-input)))
  (list M2-mode-map M2-comint-mode-map))
 
+;; menus
+
+(setq M2-common-menu
+      '(["Match previous bracketed input" M2-match-previous-bracketed-input]
+	["Match next bracketed input"     M2-match-next-bracketed-input]
+	["Set demo buffer"                M2-set-demo-buffer]
+	["Switch to demo buffer"          M2-switch-to-demo-buffer]
+	["Start demo"                     M2-demo]))
+
+(easy-menu-define M2-menu M2-mode-map
+  "Menu for Macaulay2 major mode"
+  (append
+   '("Macaulay2"
+     ["Start Macaulay2"               M2]
+     ["Send line/region to Macaulay2" M2-send-to-program]
+     ["Newline and indent"            M2-newline-and-indent]
+     ["Electric semicolon"            M2-electric-semi]
+     ["Electric right brace"          M2-electric-right-brace]
+     ["Electric tab"                  M2-electric-tab]
+     "-")
+   M2-common-menu))
+
+(easy-menu-define M2-comint-menu M2-comint-mode-map
+  "Menu for Macaulay2 Interaction major mode"
+  (append
+   '("Macaulay2 Interaction"
+     ["Send to Macaulay2"   M2-send-to-program-or-jump-to-source-code]
+     ["Go to end of prompt" M2-to-end-of-prompt]
+     ["Center point"        M2-position-point]
+     ["Jog left"            M2-jog-left]
+     ["Jog right"           M2-jog-right]
+     ["Toggle word wrap"    M2-toggle-truncate-lines]
+    "-")
+   M2-common-menu))
+
 ;; syntax
 
 ; bug: ///A"B"C/// vs ///ABC///


### PR DESCRIPTION
These menus may be useful for users to discover what functions are available in the two Macaulay2 major modes and to quickly learn their keybindings.

The menus include all functions marked `interactive`.  Functions that have a corresponding keybinding in `M2-mode` only are only displayed in the `M2-mode` menu, and similar for `M2-comint-mode`.  Functions that have a corresponding keybinding in both modes are displayed in both menus.

There are some exceptions to this:

* `M2` is bound to f12 in both modes, but really only makes sense in the `M2-mode` menu.
* `M2-send-to-program` is bound to f11 in both modes, but makes the most sense in the `M2-mode` menu, as
  `M2-send-to-program-or-jump-to-source-code` serves a similar purpose in `M2-comint-mode`.
* `M2-dynamic-complete-symbol` is marked obsolete, so it is omitted.
* `M2-electric-right-brace` has its keybinding commented out, but we include it for completeness.
* `M2-electric-tab` is set to indent-line-function for both modes, but TAB is bound to completion-at-point in `M2-comint-mode`, so we only include it in the `M2-mode` menu.

## Screenshots

### M2-mode
![m2-menu](https://user-images.githubusercontent.com/1992248/152650595-b369488b-eb31-4af6-9325-dab743a1b733.png)

### M2-comint-mode
![m2-comint-menu](https://user-images.githubusercontent.com/1992248/152650603-dcb8702a-e5c8-43de-86e0-a2d6021c641c.png)
