### PR TITLE
File position matching changes

### DIFF
--- a/M2.el
+++ b/M2.el
@@ -352,8 +352,8 @@ can be executed with \\[M2-send-to-program]."
 	   (search-backward-regexp "\\(-\\*\\|^\\)")
 	   ;; example: -*FunctionBody[../../m2/startup.m2.in:123:19-123:21]*-
 	   ;; example: -*Function[../../m2/res.m2:191:40-202:36]*-
-	   ;;                         (1    1)      (2       2)   (3      3)   (4      4)   (5      5)   (6      6)
-	   (looking-at "-\\*Function\\(Body\\)?\\[\\([^:\n]+\\):\\([0-9]+\\):\\([0-9]+\\)-\\([0-9]+\\):\\([0-9]+\\)\\]\\*-"))
+	   ;;                 (1            1)     (2       2)   (3      3)   (4      4)   (5      5)   (6      6)
+	   (looking-at "-\\*\\([[:alpha:]]+\\)\\[\\([^:\n]+\\):\\([0-9]+\\):\\([0-9]+\\)-\\([0-9]+\\):\\([0-9]+\\)\\]\\*-"))
 	 (let ((filename (buffer-substring (match-beginning 2) (match-end 2)))
 	       (linenum (string-to-number (buffer-substring (match-beginning 3) (match-end 3))))
 	       (colnum (if (match-beginning 4) (string-to-number (buffer-substring (match-beginning 4) (match-end 4))) 1))


### PR DESCRIPTION
This is an alternative to #36:
- Match file positions of the form -*Foo[...]*- for any "Foo"

cc: @d-torrance 