### PR TITLE
Fix warnings when byte-compiling

### DIFF
--- a/M2.el
+++ b/M2.el
@@ -301,13 +301,6 @@ current window added to it."
 (defun M2-update-screen ()
     (set-window-start (selected-window) (window-start (selected-window))))
 
-(defun M2-dynamic-complete-symbol()
-  "Dynamic completion function for Macaulay2 symbols."
-  (declare (obsolete completion-at-point "Macaulay2 1.20"))
-  (interactive)
-  (let ((word (comint-word "a-zA-Z")))
-    (if word (comint-dynamic-simple-complete word M2-symbols))))
-
 (defun M2-completion-at-point ()
   "Function used for `completion-at-point-functions' in `M2-mode' and
 `M2-comint-mode'."

--- a/M2.el
+++ b/M2.el
@@ -567,7 +567,7 @@ for more."
 	  (beginning-of-line)
 	  (if (bobp)
 	      0
-	      (previous-line 1)
+	      (forward-line -1)
 	      (M2-next-line-indent-amount))))
 
 (defun M2-in-front ()

--- a/M2.el
+++ b/M2.el
@@ -404,7 +404,8 @@ START and END to Macaulay2 inferior process in SEND-TO-BUFFER."
 	  (let* ((send-it t)
 		 (cmd (if (and
 			  (equal (point) (point-max))
-			  (equal (current-buffer) (save-excursion (set-buffer send-to-buffer))))
+			  (equal (current-buffer)
+				 (with-current-buffer send-to-buffer)))
 			 (if (equal (point)
 				    (save-excursion
 				      (M2-to-end-of-prompt)
@@ -526,8 +527,7 @@ for more."
     (modify-frame-parameters f '((left + 20) (top + 30)))
     ; (M2)
     (make-variable-buffer-local 'comint-scroll-show-maximum-output)
-    (save-excursion
-      (set-buffer "*M2*")
+    (with-current-buffer "*M2*"
       (setq comint-scroll-show-maximum-output t))))
 
 (defun M2-info-help (string)
@@ -608,8 +608,7 @@ for more."
 		       (indent-to i))))))
 
 (defvar M2-demo-buffer
-  (save-excursion
-    (set-buffer (get-buffer-create "*M2-demo-buffer*"))
+  (with-current-buffer (get-buffer-create "*M2-demo-buffer*")
     (M2-mode)
     (current-buffer))
   "The buffer from which lines are obtained by M2-send-to-program when the

--- a/M2.el
+++ b/M2.el
@@ -411,7 +411,6 @@ START and END to Macaulay2 inferior process in SEND-TO-BUFFER."
 				      (if (looking-at "[ \t]+") (goto-char (match-end 0)))
 				      (point)))
 			     (let* ((s (current-buffer))
-				    (db (set-buffer M2-demo-buffer))
 				    (bol (progn (beginning-of-line) (point)))
 				    (eol (progn (end-of-line) (point)))
 				    (eob (point-max))
@@ -523,9 +522,7 @@ for more."
 	      (set-frame-font ; use (w32-select-font) to get good font names under windows
 	       (cond ((eq window-system 'w32) "-*-Lucida Console-bold-r-*-*-19-142-*-*-c-*-*-ansi-")
 		     ((eq window-system 'x) "-adobe-courier-bold-r-normal--24-240-75-75-m-150-iso8859-1")
-		     (t "12x24")))))
-	 (width (frame-pixel-width))
-	 (height (frame-pixel-height)))
+		     (t "12x24"))))))
     (modify-frame-parameters f '((left + 20) (top + 30)))
     ; (M2)
     (make-variable-buffer-local 'comint-scroll-show-maximum-output)

--- a/M2.el
+++ b/M2.el
@@ -526,7 +526,6 @@ for more."
 		     (t "12x24"))))))
     (modify-frame-parameters f '((left + 20) (top + 30)))
     ; (M2)
-    (make-variable-buffer-local 'comint-scroll-show-maximum-output)
     (with-current-buffer "*M2*"
       (setq comint-scroll-show-maximum-output t))))
 


### PR DESCRIPTION
These commits fix the following warnings when running `M-x byte-compile-file` on `M2.el`:

```
In M2-dynamic-complete-symbol:
M2.el:309:15:Warning: ‘comint-dynamic-simple-complete’ is an obsolete function
    (as of 24.1); use ‘completion-in-region’ instead.
M2.el:403:1:Warning: Unused lexical variable ‘db’

In M2--send-to-program-helper:
M2.el:411:27:Warning: Use ‘with-current-buffer’ rather than
    save-excursion+set-buffer
M2.el:515:1:Warning: Unused lexical variable ‘height’
M2.el:515:1:Warning: Unused lexical variable ‘width’

In M2-demo:
M2.el:536:30:Warning: ‘make-variable-buffer-local’ not called at toplevel
M2.el:538:34:Warning: Use ‘with-current-buffer’ rather than
    save-excursion+set-buffer

In M2-this-line-indent-amount:
M2.el:577:12:Warning: ‘previous-line’ is for interactive use only; use
    ‘forward-line’ with negative argument instead.
M2.el:620:1:Warning: Use ‘with-current-buffer’ rather than
    save-excursion+set-buffer
```