### PR TITLE
M2-blink-region-flag updates

### DIFF
--- a/M2.el
+++ b/M2.el
@@ -629,7 +629,7 @@ cursor is at the end of the buffer.  Set it with M2-set-demo-buffer." )
 
 ;;; "blink" evaluated region (heavily inspired by ESS)
 
-(defcustom M2-blink-region-flag nil
+(defcustom M2-blink-region-flag t
   "If non-nil, evaluated region is highlighted for `M2-blink-delay' seconds."
   :type 'boolean
   :group 'Macaulay2)

--- a/M2.el
+++ b/M2.el
@@ -146,6 +146,8 @@
      ["Send buffer from here to Macaulay2"
       M2-send-buffer-from-here-to-end-to-program]
      ["Send paragraph to Macaulay2"   M2-send-paragraph-to-program]
+     ["Highlight evaluated region"    M2-toggle-blink-region-flag
+      :style toggle :selected M2-blink-region-flag]
      ["Newline and indent"            M2-newline-and-indent]
      ["Electric semicolon"            M2-electric-semi]
      ["Electric right brace"          M2-electric-right-brace]

--- a/M2.el
+++ b/M2.el
@@ -653,6 +653,11 @@ that `M2-blink-region-flag' is non-nil"
                     (lambda ()
                       (delete-overlay M2-current-region-overlay)))))
 
+(defun M2-toggle-blink-region-flag ()
+  "Toggle the value of `M2-blink-region-flag'."
+  (interactive)
+  (setq M2-blink-region-flag (not M2-blink-region-flag)))
+
 ; enable syntax highlighting:
 (add-hook 'M2-comint-mode-hook 'turn-on-font-lock)
 (add-hook 'M2-mode-hook 'turn-on-font-lock)


### PR DESCRIPTION
By default, we turn the new `M2-blink-region-flag` variable (which determines whether we highlight the evaluated region for a moment, inspired by ESS -- see #38) on.

Also, we add a new function, `M2-toggle-blink-region-flag` to toggle the value of this variable and add a menu entry that calls this function.