### PR TITLE
Don't flag timestamps as file locations

### DIFF
--- a/M2.el
+++ b/M2.el
@@ -379,7 +379,8 @@ can be executed with \\[M2-send-to-program]."
 (defvar M2-transform-file-match-alist
   '(("^stdio$" nil)
     ("^currentString$" nil)
-    ("^Macaulay2/Core/startup\\.m2\\.in$" nil))
+    ("^Macaulay2/Core/startup\\.m2\\.in$" nil)
+    ("^[0-9][0-9]$" nil))
   "List of filenames not to match in Macaulay2 output.")
 
 (defun M2-send-input ()


### PR DESCRIPTION
Our regular expressions flag any string ending in ":[0-9]+:[0-9]+" as a file location, including timestamps, e.g. the one in version#"compile time".

We add a new element to compilation-transform-file-match-alist so that compilation mode knows not to make any filenames consisting of two digits (i.e., the hour, since the minute and seconds are interpreted as row and column number) clickable.

### Before
![image](https://github.com/Macaulay2/M2-emacs/assets/1992248/8571b53a-a065-4ec3-8764-21bb5c701b18)

### After
![image](https://github.com/Macaulay2/M2-emacs/assets/1992248/b121e2f1-c1fd-42a8-98f9-526d8049a8d7)

