### PR TITLE
Don't match filenames with opening bracket in regex

### DIFF
--- a/M2.el
+++ b/M2.el
@@ -351,8 +351,8 @@ can be executed with \\[M2-send-to-program]."
     ;; error messages, e.g.,
     ;; i1 : load "packages/Macaulay2Doc/demo1.m2"; g 2
     ;; packages/Macaulay2Doc/demo1.m2:8:12:(3):[2]: error: division by zero
-    ;;  (1           1)   (2      2)   (3      3)
-    ("\\([^:\n\r\s]+\\):\\([0-9]+\\):\\([0-9]+\\):([0-9]+):\\[[0-9]+\\]"
+    ;;  (1              1)   (2      2)   (3      3)
+    ("\\([^\\[:\n\r\s]+\\):\\([0-9]+\\):\\([0-9]+\\):([0-9]+):\\[[0-9]+\\]"
      1 2 3)
     ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
     ;; net(FilePosition) (debugging.m2) ;;
@@ -366,8 +366,8 @@ can be executed with \\[M2-send-to-program]."
     ;; no end line/column numbers, e.g.,:
     ;; i2 : locate makeDocumentTag rank
     ;; o2 = ../Macaulay2Doc/functions/rank-doc.m2:34:0
-    ;;  (1           1)   (2      2)   (3      3)
-    ("\\([^:\n\r\s]+\\):\\([0-9]+\\):\\([0-9]+\\)"
+    ;;  (1              1)   (2      2)   (3      3)
+    ("\\([^\\[:\n\r\s]+\\):\\([0-9]+\\):\\([0-9]+\\)"
      1 2 3 0))
   "Regular expressions for matching file positions in Macaulay2 output.")
 


### PR DESCRIPTION
Filenames are frequently surrounded by square brackets because of net(Function).  We were omitting the opening square bracket from the regex in one of the three cases, but not all, which was leading to some incorrect behavior.

---

This fixes the issue I mentioned in https://github.com/Macaulay2/M2/pull/3026#issue-2025171322 .  In particular, consider the code below:

```m2
i1 : x -> x

o1 = -*Function[stdio:1:2-1:5]*-

o1 : FunctionClosure
```

Currently, the second regex (which already doesn't allow `[`) matches `stdio:1:2-1:5`, but sees that the filename is `stdio`, which is  blacklisted, so we move to the third regex (which has been allowing `[`), and that thinks that the filename is `-*Function[stdio`, which is obviously incorrect.

So we omit `[` from the third regex (which is for `DocumentTag` locations that don't have an ending line/column number), and even though it probably won't matter, from the first regex (for error messages), too.