### PR TITLE
Remove "infoHelp" cruft from output

### DIFF
--- a/M2.el
+++ b/M2.el
@@ -50,7 +50,7 @@
   "Major mode for interacting with a Macaulay2 process.\n\n\\{M2-comint-mode-map}"
   (M2-common)
   (setq comint-prompt-regexp M2-comint-prompt-regexp)
-  (add-hook 'comint-output-filter-functions 'M2-info-help nil t)
+  (add-hook 'comint-preoutput-filter-functions 'M2-info-help nil t)
   (setq-local compilation-error-regexp-alist M2-error-regexp-alist)
   (setq-local compilation-transform-file-match-alist
 	      M2-transform-file-match-alist)
@@ -534,8 +534,11 @@ for more."
 
 (defun M2-info-help (string)
   (save-excursion
-    (when (string-match "-\\* infoHelp: \\(.*\\) \\*-" string)
-      (info-other-window (match-string 1 string)))))
+    (if (string-match "-\\* infoHelp: \\(.*\\) \\*-" string)
+	(let ((end (1+ (match-end 0))))
+	  (info-other-window (match-string 1 string))
+	  (substring string end))
+      string)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; M2-mode

--- a/M2.el
+++ b/M2.el
@@ -533,12 +533,11 @@ for more."
       (setq comint-scroll-show-maximum-output t))))
 
 (defun M2-info-help (string)
-  (save-excursion
-    (if (string-match "-\\* infoHelp: \\(.*\\) \\*-" string)
-	(let ((end (1+ (match-end 0))))
-	  (info-other-window (match-string 1 string))
-	  (substring string end))
-      string)))
+  (if (string-match "-\\* infoHelp: \\(.*\\) \\*-" string)
+      (let ((end (1+ (match-end 0))))
+	(save-excursion (info-other-window (match-string 1 string)))
+	(substring string end))
+    string))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; M2-mode


### PR DESCRIPTION
When run inside Emacs, `infoHelp` prints a little message to tell Emacs how to open the appropriate info file using `info.el`.  But the user doesn't need to see that, so we remove it.

### Before
```m2
i1 : infoHelp "ideal"
-* infoHelp: (Macaulay2Doc)ideal *-

i2 : 
```


### After
```m2
i1 : infoHelp "ideal"

i2 : 
```
