### PR TITLE
Indentation updates

### DIFF
--- a/M2.el
+++ b/M2.el
@@ -77,7 +77,6 @@
 ;; key bindings
 
 (define-key M2-mode-map "\177" 'backward-delete-char-untabify)
-(define-key M2-mode-map "\^M" 'M2-newline-and-indent)
 ;; (define-key M2-mode-map "}" 'M2-electric-right-brace)
 (define-key M2-mode-map ";" 'M2-electric-semi)
 ;; (define-key M2-mode-map "\^Cd" 'M2-find-documentation)
@@ -148,7 +147,6 @@
      ["Send paragraph to Macaulay2"   M2-send-paragraph-to-program]
      ["Highlight evaluated region"    M2-toggle-blink-region-flag
       :style toggle :selected M2-blink-region-flag]
-     ["Newline and indent"            M2-newline-and-indent]
      ["Electric semicolon"            M2-electric-semi]
      ["Electric right brace"          M2-electric-right-brace]
      ["Electric tab"                  M2-electric-tab]
@@ -559,7 +557,7 @@ for more."
      (interactive)
      (insert ?\;)
      (and (eolp) (M2-next-line-blank) (= 0 (M2-paren-change))
-	 (M2-newline-and-indent)))
+	 (newline nil t)))
 
 (defun M2-next-line-indent-amount ()
      (+ (current-indentation) (* (M2-paren-change) M2-indent-level)))
@@ -584,16 +582,13 @@ for more."
 	  (or (eobp)
 	      (progn (forward-char) (M2-blank-line)))))
 
-(defun M2-newline-and-indent ()
-     "Start a new line and indent it properly for Macaulay2 code."
-     (interactive)
-     (newline)
-     (indent-to (M2-this-line-indent-amount)))
+(define-obsolete-function-alias
+  'M2-newline-and-indent 'newline "1.23")
 
 (defun M2-electric-right-brace()
      (interactive)
      (self-insert-command 1)
-     (and (eolp) (M2-next-line-blank) (< (M2-paren-change) 0) (M2-newline-and-indent)))
+     (and (eolp) (M2-next-line-blank) (< (M2-paren-change) 0) (newline nil t)))
 
 (defcustom M2-insert-tab-commands '(indent-for-tab-command org-cycle)
   "Commands for which `M2-electric-tab' should insert a tab."

--- a/M2.el
+++ b/M2.el
@@ -595,19 +595,24 @@ for more."
      (self-insert-command 1)
      (and (eolp) (M2-next-line-blank) (< (M2-paren-change) 0) (M2-newline-and-indent)))
 
+(defcustom M2-insert-tab-commands '(indent-for-tab-command org-cycle)
+  "Commands for which `M2-electric-tab' should insert a tab."
+  :type '(repeat function)
+  :group 'Macaulay2)
+
 (defun M2-electric-tab ()
-     (interactive)
-     (if (or (not (M2-in-front)) (M2-blank-line))
-	 (indent-to (+ (current-column) M2-indent-level))
-	 (let ((i (M2-this-line-indent-amount))
-	       (j (current-indentation)))
-	      (if (not (= i j))
-		  (progn
-		       (if (< i j)
-			    (delete-region (progn (beginning-of-line) (point))
-					   (progn (back-to-indentation) (point)))
-			    (back-to-indentation))
-		       (indent-to i))))))
+  "`indent-line-function' for Macaulay2.
+If called by command in `M2-insert-tab-commands', and if the point is either
+to right of non-whitespace characters in the same line or if the line
+is blank, then insert `M2-indent-level' spaces.  Otherwise, indent the
+line based on the depth of the parentheses in the code."
+  (interactive)
+  (indent-to
+   (prog1 (if (and (memq this-command M2-insert-tab-commands)
+		   (or (not (M2-in-front)) (M2-blank-line)))
+	      (+ (current-column) M2-indent-level)
+	    (M2-this-line-indent-amount))
+     (delete-horizontal-space))))
 
 (defvar M2-demo-buffer
   (with-current-buffer (get-buffer-create "*M2-demo-buffer*")


### PR DESCRIPTION
This is an improved version of #18, which was eventually reverted (#22).  The proposal is to keep the same basic behavior of indentation in `M2-mode`, but with a few improvements:

* `M2-electric-tab` now checks to see if it was called from `newline`, and if it was, replicates the behavior of `M2-newline-and-indent`.  This means that we can deprecate `M2-newline-and-indent` and just use `newline`, which is great because it has a lot more features.  For example, users can now turn off automatic indentation after pressing <kbd>Return</kbd> by disabling `electric-indent-mode`.
* Previously, we cleaned up the whitespace while indenting in one case (when the current indentation was further than it should have been and we had to move it back), but now we clean it up in all cases.  So for example, pressing <kbd>Tab</kbd> a bunch of times on a blank line won't result in alternating tab characters and spaces, but a bunch of tab characters possibly followed by spaces.
* `M2-electric-tab` is now documented!