### PR TITLE
Deprecate M2-send-input in favor of comint-send-input

### DIFF
--- a/M2.el
+++ b/M2.el
@@ -106,7 +106,6 @@
 (define-key M2-comint-mode-map [ (control C) r ] 'scroll-right)
 ;(define-key M2-comint-mode-map [ f8 ] 'switch-to-completions)
 (define-key M2-comint-mode-map [ (control C) c ] 'switch-to-completions)
-(define-key M2-comint-mode-map "\r" 'M2-send-input)
 ;; (define-key M2-comint-mode-map [ (control C) d ] 'M2-find-documentation)
 
 (mapc
@@ -159,7 +158,7 @@
   "Menu for Macaulay2 Interaction major mode"
   (append
    '("Macaulay2 Interaction"
-     ["Send to Macaulay2"   M2-send-input]
+     ["Send to Macaulay2"   comint-send-input]
      ["Go to end of prompt" M2-to-end-of-prompt]
      ["Center point"        M2-position-point]
      ["Jog left"            M2-jog-left]
@@ -378,14 +377,11 @@ can be executed with \\[M2-send-to-program]."
     ("^[0-9][0-9]$" nil))
   "List of filenames not to match in Macaulay2 output.")
 
-(defun M2-send-input ()
-  "Send the input to the Macaulay2 interpreter using `comint-send-input'."
-  (interactive)
-  (let ((comint-use-prompt-regexp t))
-    (comint-send-input)))
+(define-obsolete-function-alias
+  'M2-send-input 'comint-send-input "1.23")
 
 (define-obsolete-function-alias
-  'M2-send-to-program-or-jump-to-source-code 'M2-send-input "1.22")
+  'M2-send-to-program-or-jump-to-source-code 'comint-send-input "1.22")
 
 (defun M2--get-send-to-buffer ()
   "Helper function for `M2-send-to-program` and friends.  Gets buffer for


### PR DESCRIPTION
The only difference is that we were forcing `comint-use-prompt-regexp` to be `t`, but sending code to Macaulay2 works just fine whether it's `t` or `nil`.  The value determines whether we send just a single line or the entire input field to the M2 process when scrolling up to previous inputs and pressing <kbd>Return</kbd>.  Let's let the user choose the desired behavior by setting `comint-use-prompt-regexp` to `t` if they choose.  (It defaults to `nil` globally).

Here's an example.  Suppose we enter the following (using <kbd>C</kbd>-<kbd>j</kbd> for the newlines), and then call `comint-send-input`:

```m2
i1 : 1
2
3

o1 = 1

i2 : 
o2 = 2

i3 : 
o3 = 3
```

Now suppose we scroll up to the very first line with `comint-use-regexp` set to `nil` and call `comint-send-input`.  We get all three lines:

```m2
i4 : 1
2
3

o4 = 1

i5 : 
o5 = 2

i6 : 
o6 = 3
```

Now suppose we do it again, but after setting `comint-use-regexp` to `t`.  We just get the first line:

```m2
i7 : 1

o7 = 1

i8 : 
```

Here's the commit where it was originally set to `t`: https://github.com/Macaulay2/M2-emacs/commit/6449756793c575f2e26f3cb43e21663f4e969b8e  What was the problem this was trying to solve?