### PR TITLE
Determine indentation based on the last non-blank line

### DIFF
--- a/M2.el
+++ b/M2.el
@@ -532,11 +532,15 @@ for more."
      (+ (current-indentation) (* (M2-paren-change) M2-indent-level)))
 
 (defun M2-this-line-indent-amount ()
+     "Determine how much to indent the current line."
      (save-excursion
 	  (beginning-of-line)
 	  (if (bobp)
 	      0
 	      (forward-line -1)
+	      ;; if the previous line is blank, then keep going
+	      (while (and (not (bobp)) (looking-at-p "[[:blank:]]*$"))
+		(forward-line -1))
 	      (M2-next-line-indent-amount))))
 
 (defun M2-in-front ()


### PR DESCRIPTION
One thing that I broke in a recent pull request (probably #52) was preserving indentation between blank lines.

For example, suppose we have something like the following:

```m2
f = x -> (

    x + 2)
```

We want the `x + 2` indented since it's inside the parentheses.  But currently, when Emacs is determining the indentation of the third line, it looks back to the second line, sees that there's nothing there, and figures that there should be no indentation.  So we end up with:

```m2
f = x -> (

x + 2)
```

With this PR, we keep going back until we either hit a non-blank line or the beginning of the buffer to determine the indentation.

We also add a docstring to the `M2-this-line-indent-amount` function.

Cc: @DanGrayson

