### PR TITLE
Look for filenames enclosed in double quotes

### DIFF
--- a/M2.el
+++ b/M2.el
@@ -353,8 +353,8 @@ can be executed with \\[M2-send-to-program]."
     ;; error messages, e.g.,
     ;; i1 : load "packages/Macaulay2Doc/demo1.m2"; g 2
     ;; packages/Macaulay2Doc/demo1.m2:8:12:(3):[2]: error: division by zero
-    ;;  (1              1)   (2      2)   (3      3)
-    ("\\([^\\[:\n\r\s]+\\):\\([0-9]+\\):\\([0-9]+\\):([0-9]+):\\[[0-9]+\\]"
+    ;;  (1                                           1)   (2      2)   (3      3)
+    ("\\(?:\\(?1:[^\\[:\n\r\s]+\\)\\|\"\\(?1:.+\\)\"\\):\\([0-9]+\\):\\([0-9]+\\):([0-9]+):\\[[0-9]+\\]"
      1 2 3)
     ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
     ;; net(FilePosition) (debugging.m2) ;;
@@ -362,15 +362,15 @@ can be executed with \\[M2-send-to-program]."
     ;; start & end line/column numbers, e.g.,:
     ;; i1 : locate (rank, Matrix)
     ;; o1 = m2/matrix1.m2:663:19-666:20
-    ;;  (1              1)   (2      2)   (3      3)   (4      4)   (5      5)
-    ("\\([^\\[:\n\r\s]+\\):\\([0-9]+\\):\\([0-9]+\\)-\\([0-9]+\\):\\([0-9]+\\)"
+    ;;  (1                                           1)   (2      2)   (3      3)   (4      4)   (5      5)
+    ("\\(?:\\(?1:[^\\[:\n\r\s]+\\)\\|\"\\(?1:.+\\)\"\\):\\([0-9]+\\):\\([0-9]+\\)-\\([0-9]+\\):\\([0-9]+\\)"
      1 (2 . 4) (3 . 5) 0)
     ;; no end line/column numbers, e.g.,:
     ;; i2 : locate makeDocumentTag rank
     ;; o2 = ../Macaulay2Doc/functions/rank-doc.m2:34:0
-    ;;  (1              1)   (2      2)   (3      3)
-    ("\\([^\\[:\n\r\s]+\\):\\([0-9]+\\):\\([0-9]+\\)"
      1 2 3 0))
+    ;;  (1                                           1)   (2      2)   (3      3)
+    ("\\(?:\\(?1:[^\\[:\n\r\s]+\\)\\|\"\\(?1:.+\\)\"\\):\\([0-9]+\\):\\([0-9]+\\)"
   "Regular expressions for matching file positions in Macaulay2 output.")
 
 (defvar M2-transform-file-match-alist


### PR DESCRIPTION
This will allow us to jump to code in files with spaces in their paths.

In particular, the filename regex used by Compilation Mode now recognizes files that either:

* Contain no spaces at all (the current behavior)
* Contain any character but are enclosed in double quotes (which will be the case for filenames containing spaces if [Macaulay2/M2#3137](https://github.com/Macaulay2/M2/pull/3137) is merged)

Thanks to my Piedmont colleague @rjlutz for the idea of using double quotes to solve the problem of identifying when spaces might belong to a filename!

If this is accepted, then I'll update the M2-emacs submodule commit in https://github.com/Macaulay2/M2/pull/3137.

Cc: @mikestillman 

Closes: #48