### PR TITLE
Remove old startup.m2.in path from ignored filenames

### DIFF
--- a/M2.el
+++ b/M2.el
@@ -376,7 +376,6 @@ can be executed with \\[M2-send-to-program]."
 (defvar M2-transform-file-match-alist
   '(("^stdio$" nil)
     ("^currentString$" nil)
-    ("^Macaulay2/Core/startup\\.m2\\.in$" nil)
     ("^[0-9][0-9]$" nil))
   "List of filenames not to match in Macaulay2 output.")
 


### PR DESCRIPTION
Prior to Macaulay2 1.22, errors that occurred in the startupString code (when M2 was built using autotools) printed a nonexistent file location (Macaulay2/Core/startup.m2.in), and so we told compilation mode not to link to it when these errors occurred. But this is no longer an issue.