### PR TITLE
Add newline when at end of file in M2-send-to-program

### DIFF
--- a/M2.el
+++ b/M2.el
@@ -423,7 +423,9 @@ SEND-TO-BUFFER."
   (M2--send-to-program-helper send-to-buffer
 			      (save-excursion (M2-to-end-of-prompt) (point))
 			      (line-end-position))
-  (forward-line))
+  (forward-line)
+  ;; add a newline after a nonempty line at the end of the buffer
+  (when (and (eobp) (not (bolp))) (newline)))
 
 (defun M2-send-to-program (send-to-buffer)
      "Send the current line except for a possible prompt, or the region, if the


### PR DESCRIPTION
This restores the original behavior of sending code to the M2 process when the last line in the source file is nonempty.

One difference between this and the original behavior is that we do not add a newline when the last line is empty.

Closes: #69