### PR TITLE
Add SMIE (Simple Minded Indentation Engine) support for M2-mode

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,8 @@
+;;; Directory Local Variables            -*- no-byte-compile: t -*-
+;;; For more information see (info "(emacs) Directory Variables")
+
+;; M2.el is the main file of the package: it carries the Package-Requires
+;; header, and the others are loaded from it.  Telling `package-lint' so
+;; lets it check them against that header, rather than reporting every
+;; dependency they use as undeclared.
+((emacs-lisp-mode . ((package-lint-main-file . "M2.el"))))

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,3 +10,7 @@ jobs:
       - name: Install Emacs
         run: sudo apt-get install -y emacs-nox
       - uses: leotaku/elisp-check@master
+      - name: Run ERT tests
+        run: |
+          emacs -Q --batch -L . -l test/M2-smie-tests.el \
+                -f ert-run-tests-batch-and-exit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,4 +13,5 @@ jobs:
       - name: Run ERT tests
         run: |
           emacs -Q --batch -L . -l test/M2-smie-tests.el \
+                -l test/M2-simple-doc-tests.el \
                 -f ert-run-tests-batch-and-exit

--- a/M2-operators.el
+++ b/M2-operators.el
@@ -1,0 +1,79 @@
+;;; M2-operators.el --- Generated Macaulay2 operator table -*- lexical-binding: t -*-
+
+;; Copyright (C) 1997-2026 The Macaulay2 Authors
+
+;; Version: 1.26.06
+;; Keywords: languages
+;; URL: https://github.com/Macaulay2/M2-emacs
+
+;;; Commentary:
+
+;; This file contains the Macaulay2 operator table, read from the parsing
+;; tables of the interpreter itself rather than transcribed by hand, so that
+;; it cannot drift as operators are added to the language.
+;;
+;; It is used to build the grammar in M2.el.  Run "make update-operators" to
+;; regenerate it.
+;;
+;; Auto-generated for Macaulay2-1.26.06. Do not modify this file manually.
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Code:
+
+(defconst M2-operators-version
+  "1.26.06"
+  "The M2 version used to generate the operator table.")
+
+(defconst M2-operators-binary
+  '((left ",")
+    (right "%=" "&=" "**=" "*=" "++=" "+=" "-=" "->" "..<=" "..=" "//=" "/=" ":=" "<-" "<<=" "<==>=" "=" "===>=" "==>=" "=>" ">>" ">>=" "??=" "@=" "@@=" "@@?=" "\\=" "\\\\=" "^**=" "^=" "^^=" "_=" "|-=" "|=" "|_=" "||=" "~=" "·=" "⊠=" "⧢=")
+    (left "<<")
+    (right "|-")
+    (right "<===" "===>")
+    (right "<==>")
+    (right "<==" "==>")
+    (right "??" "or")
+    (right "xor")
+    (right "and")
+    (right "!=" "<" "<=" "=!=" "==" "===" ">" ">=" "?" "~")
+    (left "||")
+    (right ":")
+    (left "|")
+    (left "^^")
+    (left "&")
+    (left ".." "..<")
+    (left "+" "++" "-")
+    (left "·")
+    (left "**" "⊠" "⧢")
+    (right "\\" "\\\\")
+    (left "%" "*" "/" "//")
+    (right "@")
+    (left "@@" "@@?")
+    (left "#" "#?" "." ".?" "^" "^**" "^<" "^<=" "^>" "^>=" "_" "_<" "_<=" "_>" "_>=" "|_"))
+  "Macaulay2 binary operators grouped by precedence, loosest level first.
+Each element is a row for `smie-precs->prec2'.  Adjacency and the statement
+separator are omitted, since `M2-smie-grammar' describes those itself.")
+
+(defconst M2-operators-postfix
+  '("!" "^!" "^*" "^~" "_!" "_*" "_~")
+  "Macaulay2 postfix operators.
+The closing delimiters, which the parsing tables also count as postfix,
+are omitted, since `M2-smie-grammar' describes those itself.")
+
+(provide 'M2-operators)
+
+;;; M2-operators.el ends here

--- a/M2-operators.el.in
+++ b/M2-operators.el.in
@@ -1,0 +1,55 @@
+;;; M2-operators.el --- Generated Macaulay2 operator table -*- lexical-binding: t -*-
+
+;; Copyright (C) 1997-2026 The Macaulay2 Authors
+
+;; Version: @M2VERSION@
+;; Keywords: languages
+;; URL: https://github.com/Macaulay2/M2-emacs
+
+;;; Commentary:
+
+;; This file contains the Macaulay2 operator table, read from the parsing
+;; tables of the interpreter itself rather than transcribed by hand, so that
+;; it cannot drift as operators are added to the language.
+;;
+;; It is used to build the grammar in M2.el.  Run "make update-operators" to
+;; regenerate it.
+;;
+;; @M2BANNER@
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Code:
+
+(defconst M2-operators-version
+  "@M2VERSION@"
+  "The M2 version used to generate the operator table.")
+
+(defconst M2-operators-binary
+  '(@M2BINARYOPS@)
+  "Macaulay2 binary operators grouped by precedence, loosest level first.
+Each element is a row for `smie-precs->prec2'.  Adjacency and the statement
+separator are omitted, since `M2-smie-grammar' describes those itself.")
+
+(defconst M2-operators-postfix
+  '(@M2POSTFIXOPS@)
+  "Macaulay2 postfix operators.
+The closing delimiters, which the parsing tables also count as postfix,
+are omitted, since `M2-smie-grammar' describes those itself.")
+
+(provide 'M2-operators)
+
+;;; M2-operators.el ends here

--- a/M2-simple-doc.el
+++ b/M2-simple-doc.el
@@ -1,0 +1,883 @@
+;;; M2-simple-doc.el --- SimpleDoc support for Macaulay2 docstrings -*- lexical-binding: t -*-
+
+;; Copyright (C) 1997-2026 The Macaulay2 Authors
+
+;; Version: 1.26.06
+;; Keywords: languages
+;; URL: https://github.com/Macaulay2/M2-emacs
+
+;;; Commentary:
+
+;; What is written in a "doc ///.../// " string is not Macaulay2 but
+;; SimpleDoc, the language the SimpleDoc package parses.  This file parses
+;; its structure and indents it.
+;;
+;; SimpleDoc follows the off-side rule: a section is opened by a line
+;; holding a keyword and nothing else, and its body is the following, more
+;; deeply indented lines.  Nothing closes a section; it ends at the first
+;; line indented no more deeply than its keyword, and one such line may end
+;; several sections at once.  Which keywords are legal depends on the
+;; enclosing section, and is fixed by one of the four tables below.
+;;
+;; This is why SMIE is not used here, although the rest of the mode is
+;; built on it.  A SMIE lexer returns one token per position and must move
+;; over it, and the backward lexer must be its exact inverse; the several
+;; zero-width closers that one dedent stands for cannot be spelled that
+;; way.  Nor could the tokens be trusted if they could: they would be read
+;; off the indentation, which is the very thing being computed, whereas the
+;; tokens of Macaulay2 are text and cannot change under reindentation.  And
+;; the keyword tables overlap --- `Description' is legal in both a `Node'
+;; and a `Synopsis' --- so one token would need different precedence levels
+;; in different contexts, which an operator-precedence grammar cannot say.
+;;
+;; SMIE is used for the one part of a docstring that really is Macaulay2:
+;; the body of an `Example' or `Code' section.
+;;
+;; Two things are inferred from the block rather than imposed on it, since
+;; both vary widely across Macaulay2's own packages: the column of its
+;; top-level sections, and the size of one indentation step.
+;; `M2-simple-doc-indent-level' is only the fallback for a block that
+;; offers no evidence yet.  More generally, where a line is the first of
+;; its kind in a section --- its first subsection, its first body line ---
+;; its column is the author's choice and is left alone; the ones after it
+;; are aligned with it.  Only the first of anything has nothing to be
+;; measured against, and computing a column for it instead would drag its
+;; siblings after it.
+;;
+;; The one distinction to hold on to while reading the rest is between an
+;; indentation the writer asked for by pressing TAB and one taken in the
+;; course of reindenting a whole file.  In this language they cannot be
+;; the same.  Which section a line belongs to is decided by its
+;; indentation and nothing else, so moving a line is not a matter of
+;; presentation: it can promote a line of a paragraph into a section, or
+;; split one example into two, and change what is rendered and what
+;; `installPackage' runs.  So `indent-region' never restructures a
+;; docstring --- it aligns what is already there and otherwise keeps its
+;; hands off --- while TAB does what it is asked, including the things
+;; bulk reindentation must not do.  `M2-simple-doc--explicit-p' is that
+;; distinction, and several rules below turn on it.
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'smie)
+
+;; Defined in M2.el, which requires this file rather than the other way
+;; round, as M2-symbols.el and M2-operators.el are.
+(declare-function M2-inside-simple-doc-p "M2" (&optional pos))
+(defvar M2-smie--top-level-column)
+
+(defcustom M2-simple-doc-indent-level 2
+  "Fallback indentation increment inside a SimpleDoc string.
+The increment is normally inferred from the string itself, since
+Macaulay2's own packages are written in steps of anything from one column
+to eight.  This is used only where there is nothing to infer it from,
+which is to say while the first section of a docstring is being typed."
+  :type 'integer
+  :group 'M2)
+
+(defcustom M2-simple-doc-string-openers '("doc" "document" "multidoc")
+  "Words introducing a ///.../// string written in SimpleDoc.
+Such a string is indented as SimpleDoc.  A ///.../// introduced by any
+other word is either Macaulay2 code, if the word is in
+`M2-code-string-openers', or simply a string."
+  :type '(repeat string)
+  :group 'M2)
+
+(defconst M2-simple-doc--whitespace " \t\r\f\v"
+  "The characters SimpleDoc passes over at either end of a line.
+Not a newline: these are the ones that can stand inside one.")
+
+(defconst M2-simple-doc--tab-width 8
+  "The width of a tab in a SimpleDoc string.
+SimpleDoc measures indentation in columns, with a tab advancing to the
+next multiple of this, whatever `tab-width' may be in the buffer.")
+
+;;; The keyword tables.
+
+;; Four tables, one per context, exactly as in SimpleDoc.m2.  `Synopsis'
+;; is deliberately absent from the synopsis table: a synopsis does not
+;; nest.
+
+(defconst M2-simple-doc--tables
+  '((node         "Node" "Key" "Headline" "Usage" "Inputs" "Outputs"
+                  "Consequences" "Description" "Synopsis" "Acknowledgement"
+                  "Contributors" "References" "Citation" "Caveat" "SeeAlso"
+                  "Subnodes" "SourceCode" "ExampleFiles")
+    (synopsis     "Heading" "BaseFunction" "Usage" "Inputs" "Outputs"
+                  "Consequences" "Description")
+    (description  "Text" "Tree" "Example" "CannedExample" "Pre" "Code")
+    (consequences "Item"))
+  "The four SimpleDoc keyword tables.
+The car of each entry names a context and the cdr lists the keywords
+legal there.  The node table is also the one in force at the top level of
+a docstring.")
+
+(defconst M2-simple-doc--bodies
+  ;; KEYWORD           TABLE IN ITS BODY   SHAPE OF ITS BODY
+  '(("Node"            node                sections)
+    ("Synopsis"        synopsis            sections)
+    ("Description"     description         sections)
+    ("Consequences"    consequences        sections)
+    ("Key"             nil                 lines)
+    ("SeeAlso"         nil                 lines)
+    ("SourceCode"      nil                 lines)
+    ("Headline"        nil                 lines)
+    ("Heading"         nil                 lines)
+    ("BaseFunction"    nil                 lines)
+    ("Text"            nil                 lines)
+    ("Caveat"          nil                 lines)
+    ("Acknowledgement" nil                 lines)
+    ("Contributors"    nil                 lines)
+    ("References"      nil                 lines)
+    ("Item"            nil                 lines)
+    ("Inputs"          nil                 lines)
+    ("Outputs"         nil                 lines)
+    ("Subnodes"        nil                 lines)
+    ("Tree"            nil                 lines)
+    ("Example"         nil                 example)
+    ("Code"            nil                 code)
+    ("Usage"           nil                 verbatim)
+    ("Pre"             nil                 verbatim)
+    ("CannedExample"   nil                 verbatim)
+    ("Citation"        nil                 verbatim)
+    ("ExampleFiles"    nil                 verbatim))
+  "For each SimpleDoc keyword, what its body holds.
+The second element is the keyword table in force inside it, or nil if it
+holds no sections.  The third is the shape of the body:
+
+`sections'  further sections, and nothing else;
+`lines'     text, one line at a time --- prose, keys, item lists and
+            menus alike.  Every line is stripped before SimpleDoc uses
+            it, so the indentation of such a line carries nothing beyond
+            the nesting it expresses;
+`code'      Macaulay2, indented by SMIE;
+`example'   Macaulay2 too, but grouped into separate examples by its
+            indentation, so that SMIE may not move a line onto or off the
+            base column;
+`verbatim'  text whose indentation is part of the content, and which is
+            therefore never reindented.")
+
+(defconst M2-simple-doc--keyword-regexp
+  (concat (regexp-opt (mapcar #'car M2-simple-doc--bodies) t)
+          "[" M2-simple-doc--whitespace "]*$")
+  "Regexp matching a line that holds a SimpleDoc keyword and nothing else.
+Matching this is much cheaper than taking the text of the line and
+looking it up, and all but a few lines of a docstring fail it.  Whether
+the keyword is legal where it stands is a separate question, which
+`M2-simple-doc--admits-p' answers.")
+
+(defun M2-simple-doc--keyword-on-line ()
+  "Return the SimpleDoc keyword on the line at point, or nil.
+A keyword line holds a keyword and nothing else --- `Headline' is one,
+`Headline blah' is an error --- and only such a line can open a section,
+so this is the whole of what the parser needs to read from a line.  It is
+one regexp rather than a string taken out of the buffer and looked up,
+which matters: this runs for every line of the docstring above whichever
+one is being indented or fontified."
+  (save-excursion
+    (forward-line 0)
+    (skip-chars-forward M2-simple-doc--whitespace (line-end-position))
+    (and (looking-at M2-simple-doc--keyword-regexp)
+         (match-string-no-properties 1))))
+
+(defsubst M2-simple-doc--admits-p (table keyword)
+  "Return non-nil if TABLE, a context name, admits KEYWORD."
+  (and table keyword
+       (member keyword (cdr (assq table M2-simple-doc--tables)))))
+
+(defsubst M2-simple-doc--body-table (keyword)
+  "Return the keyword table in force inside KEYWORD's body."
+  (nth 1 (assoc keyword M2-simple-doc--bodies)))
+
+(defsubst M2-simple-doc--body-shape (keyword)
+  "Return the shape of KEYWORD's body, or nil if there is no such keyword.
+The shapes are `sections', `lines', `code', `example' and `verbatim', and
+`M2-simple-doc--bodies' describes them."
+  (nth 2 (assoc keyword M2-simple-doc--bodies)))
+
+;;; Reading a line.
+
+(defun M2-simple-doc--indentation ()
+  "Return the SimpleDoc indent of the line at point, or nil if it is blank.
+A space counts one column, a tab advances to the next multiple of
+`M2-simple-doc--tab-width', and a carriage return returns to column zero.
+A line holding nothing but those is blank, which SimpleDoc treats as an
+infinite indentation rather than as column zero --- which is what lets a
+blank line continue a section rather than end it."
+  (save-excursion
+    (forward-line 0)
+    (let ((column 0) (eol (line-end-position)) (done nil))
+      (while (not done)
+        (if (>= (point) eol)
+            (setq column nil done t)
+          (pcase (char-after)
+            (?\s (setq column (1+ column)) (forward-char 1))
+            (?\t (setq column (* M2-simple-doc--tab-width
+                                 (1+ (/ column M2-simple-doc--tab-width))))
+                 (forward-char 1))
+            (?\r (setq column 0) (forward-char 1))
+            (_ (setq done t)))))
+      column)))
+
+(defun M2-simple-doc--comment-line-p ()
+  "Return non-nil if the line at point vanishes before it is ever parsed.
+Lines matching \"^[[:space:]]*--\" are deleted outright before any
+indentation is measured, so such a line can never break a block, end a
+paragraph, or separate two examples, however it is indented."
+  (save-excursion
+    (forward-line 0)
+    (looking-at-p (concat "[" M2-simple-doc--whitespace "]*--"))))
+
+;;; The block parser.
+
+;; `splitByIndent' keeps a running indent and starts a new block at every
+;; line not more deeply indented than it.  A frame here stands for one such
+;; line, and the running indent is the innermost frame's, so the whole
+;; discipline is "pop while this line is no deeper than the top frame".
+;; That reproduces the floor rule exactly, including its one surprise: the
+;; running indent only ever decreases, so a keyword indented less than its
+;; siblings silently swallows them rather than standing beside them.
+;;
+;; A frame is pushed for every line, not just for a keyword line.  A line
+;; that is not a keyword admits nothing, which is what makes a keyword
+;; typed inside a body climb back out to the section that does admit it.
+
+(cl-defstruct (M2-simple-doc--frame
+               (:constructor M2-simple-doc--frame
+                             (indent keyword position
+                              &aux (table (M2-simple-doc--body-table keyword))))
+               (:copier nil))
+  "One line of a docstring, and what has been seen inside it so far.
+INDENT is the column it stands in and POSITION where it begins.  KEYWORD
+is the section it opens, or nil if it opens none, and TABLE the keyword
+table then in force in its body.  SECTION-ANCHOR and BODY-ANCHOR record
+the column of the first subsection and of the first body line it was
+found to have, so that the ones after them can be aligned with them."
+  indent keyword table section-anchor body-anchor position)
+
+(defsubst M2-simple-doc--root-frame-p (frame)
+  "Return non-nil if FRAME is the one standing for the docstring itself.
+Nothing encloses it, so it is the one frame with no line of its own, and
+it is given an indent no line can have."
+  (< (M2-simple-doc--frame-indent frame) 0))
+
+(defun M2-simple-doc--mode-of (values fallback)
+  "Return the most common member of VALUES, or FALLBACK if there is none.
+Ties are broken towards the value seen first, which is the one nearest
+the top of the docstring."
+  ;; VALUES arrives bottom-to-top, having been pushed as the docstring was
+  ;; read, and `>=' lets each later one take a tie.  Walking it as it comes
+  ;; therefore leaves the topmost winner standing.
+  (let ((counts nil) (best nil) (best-count 0))
+    (dolist (value values)
+      (let ((cell (assq value counts)))
+        (if cell (setcdr cell (1+ (cdr cell)))
+          (push (setq cell (cons value 1)) counts))
+        (when (>= (cdr cell) best-count)
+          (setq best value best-count (cdr cell)))))
+    (or best fallback)))
+
+(defun M2-simple-doc--terminated-p (end)
+  "Return non-nil if a closing /// stands at END.
+A docstring still being typed has none, and END is then the end of the
+buffer rather than a delimiter."
+  (save-excursion (goto-char end) (looking-at-p "///")))
+
+(defun M2-simple-doc--text-end (end)
+  "Return the end of the SimpleDoc text of a string closing at END.
+That is the beginning of the line holding the closing ///, when the
+string is closed and nothing but whitespace precedes the /// there, and
+END itself otherwise."
+  (save-excursion
+    (goto-char end)
+    (let ((bol (line-beginning-position)))
+      (if (and (M2-simple-doc--terminated-p end)
+               (save-excursion
+                 (skip-chars-backward M2-simple-doc--whitespace bol)
+                 (= (point) bol)))
+          bol
+        end))))
+
+(defun M2-simple-doc--terminator-line-p (end)
+  "Return non-nil if the /// closing at END stands on the line at point.
+That line is not SimpleDoc but the tail of the Macaulay2 expression the
+string belongs to."
+  (and (M2-simple-doc--terminated-p end)
+       (<= (line-beginning-position) end)
+       (<= end (line-end-position))))
+
+(defun M2-simple-doc--walk (start end function)
+  "Call FUNCTION for each SimpleDoc line between START and END.
+It is called with the line's indent, the keyword it opens or nil, and the
+stack of frames enclosing it.  Blank lines and comment lines are passed over, as
+SimpleDoc passes over them.  The value is the stack of frames left open
+at END, innermost first, always ending in the frame standing for the
+docstring itself.
+
+This runs once per line of the docstring for every line indented or
+fontified in it, so it does as little per line as it can: a line is
+measured, tested against one regexp, and otherwise left untouched."
+  (let* ((root (M2-simple-doc--frame -1 nil start))
+         (stack (list root)))
+    ;; The docstring itself holds node keywords, and nothing encloses it.
+    (setf (M2-simple-doc--frame-table root) 'node)
+    (save-excursion
+      ;; The opening /// leaves the rest of its line behind it, and the
+      ;; closing one usually has a line to itself.  Neither is SimpleDoc,
+      ;; and reading either as a line of it would be no idle mistake: the
+      ;; "doc ///" line sits at the far left, so a frame for it would
+      ;; swallow the whole docstring.
+      (goto-char start)
+      (unless (bolp) (forward-line 1))
+      (setq end (max (point) (M2-simple-doc--text-end end)))
+      (while (< (point) end)
+        (let ((indent (M2-simple-doc--indentation)))
+          (unless (or (null indent) (M2-simple-doc--comment-line-p))
+            (while (and (cdr stack)
+                        (<= indent (M2-simple-doc--frame-indent (car stack))))
+              (pop stack))
+            (let* ((bol (point))
+                   (candidate (M2-simple-doc--keyword-on-line))
+                   (keyword (and (M2-simple-doc--admits-p
+                                  (M2-simple-doc--frame-table (car stack))
+                                  candidate)
+                                 candidate)))
+              (funcall function indent keyword stack)
+              (push (M2-simple-doc--frame indent keyword bol) stack))))
+        (forward-line 1)))
+    stack))
+
+(defun M2-simple-doc--steps (start end)
+  "Return the pair of indentation increments used between START and END.
+The value is a cons of the increment between a section and its
+subsections and the increment between a section and its body.  Each is
+the commonest such increment in the docstring, so that a block written in
+some other measure than `M2-simple-doc-indent-level' --- Macaulay2's own
+packages use everything from one column to eight --- is indented in the
+measure it is written in.
+
+Both are read from the whole docstring rather than from the part above
+the line being indented, since the step is a property of the block: were
+it read from above, the first subsection of every section would be
+computed from the fallback and the rest aligned to that mistake."
+  (let ((section nil) (body nil))
+    (M2-simple-doc--walk
+     start end
+     (lambda (indent keyword stack)
+       (let* ((parent (car stack))
+              (above (M2-simple-doc--frame-indent parent)))
+         (unless (M2-simple-doc--root-frame-p parent)
+           (cond
+            (keyword (push (- indent above) section))
+            ;; Only the first line of a section's body measures a step of
+            ;; SimpleDoc.  Deeper lines are the structure of something
+            ;; else --- a continuation inside an example, the description
+            ;; of an item, a nested menu --- and counting them would make
+            ;; the block look more steeply stepped than it is written.
+            ((eq (M2-simple-doc--body-shape
+                  (M2-simple-doc--frame-keyword parent))
+                 'lines)
+             (push (- indent above) body)))))))
+    (cons (M2-simple-doc--mode-of section M2-simple-doc-indent-level)
+          (M2-simple-doc--mode-of body M2-simple-doc-indent-level))))
+
+(defvar-local M2-simple-doc--steps-cache nil
+  "Memo for `M2-simple-doc--steps'.
+A cons of a key describing one docstring and the increments read from it.
+Answering means walking the whole block, and the question is asked once
+per line; the answer changes only when the block does.")
+
+(defun M2-simple-doc--cached-steps (bounds)
+  "Return the indentation increments of the docstring spanning BOUNDS."
+  (let ((key (list (car bounds) (cdr bounds) (buffer-chars-modified-tick))))
+    (unless (equal (car M2-simple-doc--steps-cache) key)
+      (setq M2-simple-doc--steps-cache
+            (cons key (M2-simple-doc--steps (car bounds) (cdr bounds)))))
+    (cdr M2-simple-doc--steps-cache)))
+
+(defun M2-simple-doc--stack (start limit)
+  "Return the stack of frames enclosing LIMIT, from a docstring at START.
+Each frame records where the first of its children of each kind sits, so
+that the later ones can be aligned with it rather than recomputed ---
+which is what keeps a block that is irregular but self-consistent from
+being rewritten.
+
+The stack is built from the lines strictly before LIMIT.  The line at
+LIMIT never pops a frame, which is what lets a misindented keyword be
+moved to where it belongs instead of being taken at its word."
+  (M2-simple-doc--walk
+   start limit
+   (lambda (indent keyword stack)
+     (let ((parent (car stack)))
+       (if keyword
+           (unless (M2-simple-doc--frame-section-anchor parent)
+             (setf (M2-simple-doc--frame-section-anchor parent) indent))
+         (unless (M2-simple-doc--frame-body-anchor parent)
+           (setf (M2-simple-doc--frame-body-anchor parent) indent)))))))
+
+(defun M2-simple-doc--enclosing-section (stack)
+  "Return the innermost frame of STACK that opened a section."
+  (cl-find-if #'M2-simple-doc--frame-keyword stack))
+
+;;; Indentation.
+
+(defun M2-simple-doc--subtree-limit ()
+  "Return the smallest indent of the lines belonging to the line at point.
+That is, of the following lines more deeply indented than this one, which
+would be stranded outside it were it moved to their level or beyond.
+Return nil when it has no such lines."
+  (save-excursion
+    (let ((own (M2-simple-doc--indentation))
+          (limit nil)
+          (done nil))
+      (when own
+        (while (not done)
+          (if (/= 0 (forward-line 1))
+              (setq done t)
+            (let ((indent (M2-simple-doc--indentation)))
+              (cond
+               ((M2-simple-doc--comment-line-p))
+               ((null indent))                  ; blank: still inside
+               ((<= indent own) (setq done t))
+               (t (setq limit (if limit (min limit indent) indent)))))))
+        limit))))
+
+(defun M2-simple-doc--frame-at (stack indent)
+  "Return the frame of STACK that a line at INDENT would hang from."
+  (cl-find-if (lambda (frame) (> indent (M2-simple-doc--frame-indent frame)))
+              stack))
+
+(defun M2-simple-doc--clamp (target parent stack)
+  "Return TARGET if the line at point may be moved there, else nil.
+PARENT is the frame the line is to hang from and STACK the frames
+enclosing it.  Moving a line changes which section it belongs to and
+which lines belong to it, and an indentation function moves one line
+while its neighbours stay put.  So refuse the move rather than
+approximate it when TARGET would
+
+  - carry the line out of PARENT altogether;
+  - put it level with the lines that have to stay inside it, which would
+    strand them outside;
+  - or leave it deep enough for some frame between it and PARENT to adopt
+    it.  A line indented past its siblings is not beside them: it is
+    inside whatever the one above it opened."
+  (let ((subtree (M2-simple-doc--subtree-limit)))
+    (and (> target (M2-simple-doc--frame-indent parent))
+         (or (null subtree) (< target subtree))
+         (eq parent (M2-simple-doc--frame-at stack target))
+         target)))
+
+(defun M2-simple-doc--align (anchor parent step stack)
+  "Return the column for a line belonging directly inside PARENT.
+ANCHOR is where PARENT's first child of this kind already sits, or nil if
+it has none, and STEP the increment to fall back on.  STACK is the frames
+enclosing the line.
+
+Align with the first child where there is one.  Where there is none this
+line *is* the first, and its column is the author's choice of how deeply
+this part of the block is stepped: SimpleDoc asks only that it be deeper
+than its parent, there is nothing to check it against, and recomputing it
+from the block's commonest step would drag its siblings after it or
+strand the ones that would not follow.  So leave it, unless the
+indentation was asked for by hand."
+  (cond
+   (anchor (M2-simple-doc--clamp anchor parent stack))
+   ((and (M2-simple-doc--explicit-p)
+         (not (M2-simple-doc--root-frame-p parent)))
+    (M2-simple-doc--clamp (+ (M2-simple-doc--frame-indent parent) step)
+                          parent stack))))
+
+(defun M2-simple-doc--body-bounds (section limit)
+  "Return the bounds of the body of SECTION, which cannot reach past LIMIT.
+The value is a cons of the position after SECTION's keyword line and the
+position where its body ends, that being the first line indented no more
+deeply than the keyword."
+  (save-excursion
+    (goto-char (M2-simple-doc--frame-position section))
+    (forward-line 1)
+    (let ((start (point))
+          (indent (M2-simple-doc--frame-indent section))
+          (end nil))
+      (while (and (null end) (< (point) limit))
+        (let ((this (M2-simple-doc--indentation)))
+          (if (and this
+                   (<= this indent)
+                   (not (M2-simple-doc--comment-line-p)))
+              (setq end (point))
+            (forward-line 1))))
+      (cons start (or end (min (point) limit))))))
+
+(defun M2-simple-doc--smie-column (base bounds)
+  "Return the column SMIE gives the line at point, with BASE as the outermost.
+BOUNDS is the extent of the section body, which is narrowed to before
+SMIE is asked.  It must be the body alone and not the whole docstring:
+the prose of the sections above is not Macaulay2, and SMIE's lexer, given
+sight of it, reads it as a string of identifiers and indents the code
+under it as their arguments.
+
+SMIE's notion of the outermost level is moved from column zero out to
+BASE, since the code is a block the section has already pushed to the
+right.  Return nil where SMIE declines to answer, as it does inside a
+string or a comment --- an example may well contain either."
+  (unwind-protect
+      (save-restriction
+        (narrow-to-region (car bounds) (cdr bounds))
+        ;; `smie-indent-calculate' indents for the point, not for the line
+        ;; the point is on --- `smie-indent-line' moves to the indentation
+        ;; before calling it, and so must this.  Reached from
+        ;; `indent-line-function', the point is wherever the writer is
+        ;; typing, which is usually the end of the line.
+        (save-excursion
+          (forward-line 0)
+          ;; The same two characters `smie-indent-line' skips, since the
+          ;; point has to reach where SMIE would have put it.
+          (skip-chars-forward " \t")
+          (let* ((M2-smie--top-level-column base)
+                 ;; `M2-syntax-propertize' demotes to punctuation every
+                 ;; delimiter a doc string leaves unbalanced, so that prose
+                 ;; cannot displace the code after it.  In here the text is
+                 ;; Macaulay2 and a bracket is unbalanced only until it is
+                 ;; closed --- which is to say for as long as it is being
+                 ;; typed, exactly when indentation is wanted.  So read
+                 ;; this much with the syntax table alone.
+                 (parse-sexp-lookup-properties nil)
+                 (column (condition-case nil (smie-indent-calculate)
+                           (error nil))))
+            (and (numberp column) column))))
+    ;; `syntax-ppss' caches what it parses, and what it parsed just now took
+    ;; no notice of those properties.  Do not leave that behind for the rest
+    ;; of the buffer to read --- and flush it widened, which is the state
+    ;; the rest of the buffer will ask in.
+    (syntax-ppss-flush-cache (car bounds))))
+
+(defsubst M2-simple-doc--nothing-on-line-p ()
+  "Return non-nil if there is nothing on the line at point to be placed.
+That is any line of whitespace, not merely an empty one: after the first
+TAB on an empty line it holds the indentation that TAB gave it, and the
+next TAB must still see it as a line with nothing on it."
+  (null (M2-simple-doc--indentation)))
+
+(defun M2-simple-doc--example-floor (section)
+  "Return the indent floor in force for the line at point in SECTION's body.
+An `Example' body is divided into separate examples the same way a
+docstring is divided into sections: a line no deeper than the running
+floor begins a new example and lowers the floor to its own column, and
+the more deeply indented lines after it continue that example.
+
+Return nil when nothing above the line has set a floor, which is to say
+the line is the first of the body."
+  (let ((limit (line-beginning-position))
+        (floor nil))
+    (save-excursion
+      (goto-char (M2-simple-doc--frame-position section))
+      (forward-line 1)
+      (while (< (point) limit)
+        (let ((indent (M2-simple-doc--indentation)))
+          (unless (or (null indent) (M2-simple-doc--comment-line-p))
+            (when (or (null floor) (<= indent floor))
+              (setq floor indent))))
+        (forward-line 1)))
+    floor))
+
+(defun M2-simple-doc--example-target (section body step)
+  "Return the column for a line of the `Example' body of SECTION.
+BODY is the extent of that body, and STEP the block's body
+increment.  A line that begins an example of its own is left exactly
+where it is: its column is what fixes the floor for the lines after it,
+so moving it would run two examples together or split one in two,
+changing what `installPackage' runs and what the transcript shows.  Only
+a line that continues an example is passed to SMIE."
+  (let ((floor (M2-simple-doc--example-floor section))
+        (current (M2-simple-doc--indentation)))
+    (cond
+     ;; The first line of the body.  There is nothing to preserve on a
+     ;; line just opened with RET, so the usual step is the best guess.
+     ((null floor)
+      (and (M2-simple-doc--nothing-on-line-p)
+           (+ (M2-simple-doc--frame-indent section) step)))
+     ;; This line begins an example of its own, and the column it begins
+     ;; at is the writer's to choose --- but a line just typed may have no
+     ;; indentation at all, and pressing TAB on it asks for it to be lined
+     ;; up with the examples above rather than left where it fell.
+     ((and current (<= current floor))
+      (and (M2-simple-doc--explicit-p) floor))
+     (t
+      (let ((column (M2-simple-doc--smie-column floor body)))
+        (cond
+         ;; SMIE would not say --- the point is in a string, or the line
+         ;; above is half-written.  A line with something on it stays
+         ;; where it is, but one just opened has to go somewhere, and the
+         ;; floor is where the example it belongs to began.
+         ((null column) (and (M2-simple-doc--nothing-on-line-p) floor))
+         ;; SMIE reads the line as the continuation of an expression: a
+         ;; bracket is still open, or the line before it ended in an
+         ;; operator.  Deeper than the floor is where it belongs, and it
+         ;; goes on being part of the same example.
+         ((> column floor) column)
+         ;; SMIE reads it as a statement of its own, and one of those
+         ;; belongs at the floor.  Moving a line that has something on it
+         ;; there makes a separate example of it and changes what
+         ;; `installPackage' runs, so that waits to be asked for; but a
+         ;; line with nothing on it has nothing to move, and is being
+         ;; opened for whatever comes next.
+         ((or (M2-simple-doc--nothing-on-line-p)
+              (M2-simple-doc--explicit-p))
+          floor)
+         (t nil)))))))
+
+(defun M2-simple-doc--target (bounds)
+  "Return the column the line at point belongs at, or nil to leave it alone.
+BOUNDS is the extent of the docstring, as `M2-inside-simple-doc-p'
+returns it."
+  (let ((indent (M2-simple-doc--indentation)))
+    (cond
+     ((M2-simple-doc--terminator-line-p (cdr bounds)) nil)
+     ;; A comment vanishes before SimpleDoc sees it, so nothing can be said
+     ;; about where it goes.
+     ((M2-simple-doc--comment-line-p) nil)
+     ;; A line that is blank but not empty keeps its whitespace, which may
+     ;; well be part of a `Pre' or an example --- unless the writer has
+     ;; pressed TAB on it, which is a request to move it and which is also
+     ;; what every TAB after the first sees, the first having filled the
+     ;; line with the whitespace this clause is about.
+     ((and (null indent)
+           (/= (line-beginning-position) (line-end-position))
+           (not (M2-simple-doc--explicit-p)))
+      nil)
+     (t
+      (let* ((steps (M2-simple-doc--cached-steps bounds))
+             (stack (M2-simple-doc--stack (car bounds)
+                                          (line-beginning-position)))
+             (keyword (M2-simple-doc--keyword-on-line))
+             (frame (and keyword (M2-simple-doc--keyword-frame stack keyword))))
+        (cond
+         ;; It names a section, and either it already heads a block where
+         ;; it sits or the writer has asked for it to be put in one.
+         ((and frame
+               (or (M2-simple-doc--explicit-p)
+                   (M2-simple-doc--section-here-p stack indent keyword)))
+          (M2-simple-doc--align (M2-simple-doc--frame-section-anchor frame)
+                                frame (car steps) stack))
+         ;; It names a section but heads no block where it sits, so to
+         ;; SimpleDoc it is body text that merely reads like a keyword.  It
+         ;; cannot be indented as body text either: any move might be the
+         ;; one that lands it beside its siblings and makes it the section
+         ;; it only looks like.  Leave it exactly where it is.
+         (frame nil)
+         (t (M2-simple-doc--body-target stack steps bounds))))))))
+
+(defun M2-simple-doc--keyword-frame (stack keyword)
+  "Return the frame of STACK whose body admits KEYWORD.
+The innermost such frame wins, which is what settles the keywords listed
+in two tables at once: a `Description' inside a `Synopsis' belongs to the
+synopsis, and one inside a `Node' to the node.  Return nil when nothing on
+the stack admits KEYWORD, in which case the line is body text that merely
+reads like a keyword."
+  (if (equal keyword "Node")
+      ;; A `Node' names a documentation node, and a docstring is a sequence
+      ;; of them.  It appears in its own body table, so one can be made to
+      ;; nest inside another, but nothing ever consumes a nested node ---
+      ;; the grammar calls that an accident of the table rather than a
+      ;; feature.  Reading it as the innermost match would let the node
+      ;; above swallow this one and every node after it, so bind it to the
+      ;; docstring itself.
+      (car (last stack))
+    (cl-find-if (lambda (frame)
+                  (M2-simple-doc--admits-p (M2-simple-doc--frame-table frame)
+                                           keyword))
+                stack)))
+
+(defun M2-simple-doc--section-here-p (stack indent keyword)
+  "Return non-nil if a line holding KEYWORD at INDENT already opens a section.
+STACK is the list of frames enclosing it.  SimpleDoc reads a word as a
+keyword only where the line's own indentation puts it directly inside a
+section whose table admits it; anywhere else the same word is just a word
+in the body of something."
+  (let ((frame (M2-simple-doc--frame-at stack indent)))
+    (and frame
+         (M2-simple-doc--admits-p (M2-simple-doc--frame-table frame) keyword))))
+
+(defun M2-simple-doc--explicit-p ()
+  "Return non-nil if this line's indentation was asked for by hand.
+A keyword line that is not yet a section head is moved into place only
+then.  Doing it under `indent-region' would let reindenting a file
+silently rewrite its documentation: a line reading `Example' inside a
+paragraph is prose to SimpleDoc, however much it looks like a section,
+and promoting it would add an example that was never there."
+  (memq this-command (bound-and-true-p M2-insert-tab-commands)))
+
+(defun M2-simple-doc--fresh-line-target (stack steps)
+  "Return the column for a line with nothing on it yet, given STACK.
+STEPS is the block's pair of inferred indentation increments.  Such a
+line has just been opened with RET, and since it is blank it popped no
+frame: the innermost is the line above.  Continue that line, or begin its
+body if it opened a section --- so that RET after `Description' lands
+where a `Text' belongs."
+  (let* ((frame (car stack))
+         (keyword (M2-simple-doc--frame-keyword frame))
+         (indent (M2-simple-doc--frame-indent frame)))
+    (cond
+     ;; Nothing above at all: the docstring is still empty.
+     ((M2-simple-doc--root-frame-p frame) M2-simple-doc-indent-level)
+     (keyword
+      (+ indent (if (eq (M2-simple-doc--body-shape keyword) 'sections)
+                    (car steps)
+                  (cdr steps))))
+     (t indent))))
+
+(defun M2-simple-doc--body-target (stack steps bounds)
+  "Return the column for a body line, given the enclosing STACK.
+STEPS is the block's pair of inferred indentation increments and BOUNDS
+the extent of the docstring."
+  (let* ((section (M2-simple-doc--enclosing-section stack))
+         (keyword (and section (M2-simple-doc--frame-keyword section)))
+         (shape (M2-simple-doc--body-shape keyword))
+         (anchor (and section (M2-simple-doc--frame-body-anchor section)))
+         (step (cdr steps)))
+    (cond
+     ;; The two bodies that hold Macaulay2 rather than text.  Both are
+     ;; handed to SMIE, over the section body alone; they differ in that an
+     ;; `Example' is divided into separate examples by its own
+     ;; indentation, which SMIE must therefore not disturb, while a `Code'
+     ;; is one parenthesized expression with no such structure to keep.
+     ((memq shape '(example code))
+      (let ((body (M2-simple-doc--body-bounds
+                   section (M2-simple-doc--text-end (cdr bounds)))))
+        (if (eq shape 'example)
+            (M2-simple-doc--example-target section body step)
+          (cond
+           (anchor (let ((column (M2-simple-doc--smie-column anchor body)))
+                     (and column (max anchor column))))
+           ;; The first line of the body fixes the dedent applied to the
+           ;; whole section, so it is the author's --- but a line just
+           ;; opened has nothing to preserve.
+           ((M2-simple-doc--nothing-on-line-p)
+            (+ (M2-simple-doc--frame-indent section) step))))))
+     ;; A line with nothing on it yet: it has no text to place, and RET
+     ;; should always land somewhere.
+     ((M2-simple-doc--nothing-on-line-p)
+      (M2-simple-doc--fresh-line-target stack steps))
+     ;; Outside any section, or inside one that holds only sections and so
+     ;; has no business holding this line: say nothing.
+     ((null section) nil)
+     ((memq shape '(nil sections verbatim)) nil)
+     ;; A line one level inside the section is one of its own: an item
+     ;; head, a key, a line of a paragraph.
+     ((eq section (car stack))
+      (M2-simple-doc--align anchor section step stack))
+     ;; A line shallower than the section's other body lines has fallen
+     ;; short of them --- typed at the left margin, most likely, since that
+     ;; is where a line starts.  Where exactly it fell is no information,
+     ;; so TAB brings it in to join them.  Bulk reindentation still leaves
+     ;; it: a line shallower than the section it appears to be in may have
+     ;; been meant to end that section.
+     ((and (M2-simple-doc--explicit-p)
+           anchor
+           (< (or (M2-simple-doc--indentation) 0) anchor))
+      (M2-simple-doc--clamp anchor section stack))
+     ;; Anything deeper hangs off one of those, and its depth is what says
+     ;; so: the description of an item, a nested menu, a continuation.
+     ;; Leave it be.
+     (t nil))))
+
+(defun M2-simple-doc--candidate-columns (bounds target)
+  "Return the columns the line at point could sensibly be given.
+BOUNDS is the extent of the docstring and TARGET the column computed for
+the line.  The value is sorted, largest first, and always holds TARGET.
+
+The candidates are the columns of the children a section already has: one
+level per enclosing section, which is what a line at that depth would be
+a part of.  In
+
+  Key
+    foo
+
+a line under `foo' can be another key, at the column `foo' stands in, or
+a new section of the node, at the column `Key' stands in --- and those
+are just the body column of the `Key' frame and the section column of the
+docstring's own."
+  (let ((columns (list target)))
+    (dolist (frame (M2-simple-doc--stack (car bounds) (line-beginning-position)))
+      (dolist (column (list (M2-simple-doc--frame-section-anchor frame)
+                            (M2-simple-doc--frame-body-anchor frame)))
+        (when (and column (>= column 0)) (push column columns))))
+    (sort (delete-dups columns) #'>)))
+
+(defun M2-simple-doc--cycling-p ()
+  "Return non-nil if this is a second or later TAB on an unwritten line.
+Repeating an indentation command is how one asks for the next
+possibility, as in `python-mode'.
+
+Unlike `python-mode' this offers the possibilities only for a line with
+nothing on it yet, where the writer is choosing what to write next and
+any level might be meant.  Once there is text on the line, what it is
+settles where it goes: a keyword belongs where its table puts it, and
+prose belongs in the section it is part of.  Cycling such a line would
+not reindent it but move it from one section to another."
+  (and (M2-simple-doc--explicit-p)
+       (eq last-command this-command)
+       (M2-simple-doc--nothing-on-line-p)))
+
+(defun M2-simple-doc--previous-column (columns indentation)
+  "Return the largest of COLUMNS below INDENTATION, or the largest of all.
+COLUMNS is sorted largest first, so the first one below INDENTATION is
+the one wanted.  Cycling runs leftwards --- the computed column is the
+likeliest and the shallower ones are the alternatives --- and comes round
+to the deepest again once there is nothing shallower left."
+  (or (cl-find-if (lambda (column) (< column indentation)) columns)
+      (car columns)))
+
+(defun M2-simple-doc-indent-line (bounds)
+  "Indent the current line of the SimpleDoc string spanning BOUNDS.
+Return `noindent' where SimpleDoc's own reading of the line makes its
+indentation something other than this function's to choose, so that
+`indent-region' and `electric-indent-mode' leave such a line alone, and t
+where the line was indented.  Never nil, which `M2-electric-tab' reads as
+meaning the line was not SimpleDoc at all.
+
+TAB pressed again on a line already indented steps it out to the next
+level that would make sense there, and around to the deepest again once
+there is nowhere further to go.  Which section a line belongs to is what
+its indentation says, and only the writer knows which was meant."
+  (let ((target (M2-simple-doc--target bounds)))
+    (when (and target (M2-simple-doc--cycling-p))
+      (setq target (M2-simple-doc--previous-column
+                    (M2-simple-doc--candidate-columns bounds target)
+                    (current-indentation))))
+    (if (null target)
+        'noindent
+      ;; SimpleDoc reckons a tab as eight columns whatever the buffer
+      ;; thinks, and `M2-mode' indents with spaces.  `indent-line-to' does
+      ;; nothing at all when the column already matches, so the lines this
+      ;; function leaves where they are keep whatever whitespace they have
+      ;; --- which matters, since a good third of Macaulay2's own
+      ;; docstrings are indented with tabs.
+      (let ((within (<= (point) (save-excursion (back-to-indentation) (point))))
+            (tab-width M2-simple-doc--tab-width)
+            (indent-tabs-mode nil))
+        ;; `indent-line-to' goes to the indentation before changing it, so
+        ;; the point has to be put back: after TAB on a line just typed it
+        ;; belongs after the text, ready for the next word.
+        (save-excursion (indent-line-to target))
+        (when within (back-to-indentation)))
+      t)))
+
+(provide 'M2-simple-doc)
+
+;;; M2-simple-doc.el ends here

--- a/M2-simple-doc.el
+++ b/M2-simple-doc.el
@@ -9,8 +9,8 @@
 ;;; Commentary:
 
 ;; What is written in a "doc ///.../// " string is not Macaulay2 but
-;; SimpleDoc, the language the SimpleDoc package parses.  This file parses
-;; its structure and indents it.
+;; SimpleDoc, the language the SimpleDoc package parses.  This file
+;; indents it and fontifies its prose.
 ;;
 ;; SimpleDoc follows the off-side rule: a section is opened by a line
 ;; holding a keyword and nothing else, and its body is the following, more
@@ -93,7 +93,8 @@ which is to say while the first section of a docstring is being typed."
 
 (defcustom M2-simple-doc-string-openers '("doc" "document" "multidoc")
   "Words introducing a ///.../// string written in SimpleDoc.
-Such a string is indented as SimpleDoc.  A ///.../// introduced by any
+Such a string is indented as SimpleDoc, and its prose is fontified as
+documentation rather than as Macaulay2.  A ///.../// introduced by any
 other word is either Macaulay2 code, if the word is in
 `M2-code-string-openers', or simply a string."
   :type '(repeat string)
@@ -877,6 +878,144 @@ its indentation says, and only the writer knows which was meant."
         (save-excursion (indent-line-to target))
         (when within (back-to-indentation)))
       t)))
+
+;;; Fontification.
+
+;; Every one of the 27 SimpleDoc keywords is also a Macaulay2 symbol, so
+;; the tables in `M2-mode-font-lock-keywords' mark up a docstring's prose
+;; as though it were code: a headline reading "a Key for the Example in
+;; the Text" comes out with three constants and two keywords in it, and a
+;; -- written in a sentence comments out the rest of the line.  The remedy
+;; is not to add colour but to withhold it, so this paints the prose over
+;; again as documentation, and is appended to those tables so that it has
+;; the last word.
+;;
+;; What it must not paint over is an @...@ block, whose contents really
+;; are Macaulay2 and have just been marked up correctly.
+
+(defconst M2-simple-doc--prose-sections
+  '("Text" "Caveat" "Acknowledgement" "Contributors" "References" "Item"
+    "Headline" "Heading" "Usage" "Pre" "CannedExample" "Citation"
+    "ExampleFiles")
+  "Sections whose body is prose, or text taken raw.
+`Key', `SeeAlso', `SourceCode', `BaseFunction', `Code' and `Example' are
+absent because their bodies are evaluated or run as Macaulay2, and the
+menu sections because their entries are mostly documentation keys.")
+
+(defconst M2-simple-doc--item-sections '("Inputs" "Outputs")
+  "Sections whose body is a list of items.
+The head of an item names a type, which is Macaulay2 and is left as such;
+the more deeply indented lines describing it are prose.")
+
+(defun M2-simple-doc--prose-line-p (stack)
+  "Return non-nil if the line whose enclosing frames are STACK is prose."
+  (let* ((section (M2-simple-doc--enclosing-section stack))
+         (keyword (and section (M2-simple-doc--frame-keyword section))))
+    (and keyword
+         (or (member keyword M2-simple-doc--prose-sections)
+             ;; An item's description, but not its head.
+             (and (member keyword M2-simple-doc--item-sections)
+                  (not (eq section (car stack))))))))
+
+(defun M2-simple-doc--line-spans ()
+  "Return the stretches of the line at point outside any @...@ block.
+The value is a list of conses, in order.  A backslash escapes the
+character after it, so a \\=\\@ is a literal at sign and opens nothing.
+An unmatched @ is an error in SimpleDoc; here it simply takes the rest of
+the line, so that one cannot swallow the buffer."
+  (save-excursion
+    (forward-line 0)
+    (let ((eol (line-end-position)) (spans nil) (start nil))
+      (skip-chars-forward M2-simple-doc--whitespace eol)
+      (setq start (point))
+      (while (< (point) eol)
+        (cond
+         ((eq (char-after) ?\\) (forward-char (min 2 (- eol (point)))))
+         ((eq (char-after) ?@)
+          (when (> (point) start) (push (cons start (point)) spans))
+          (forward-char 1)
+          (let ((done nil))
+            (while (and (not done) (< (point) eol))
+              (cond
+               ((eq (char-after) ?\\) (forward-char (min 2 (- eol (point)))))
+               ((eq (char-after) ?@) (forward-char 1) (setq done t))
+               (t (forward-char 1)))))
+          (setq start (point)))
+         (t (forward-char 1))))
+      (when (> eol start) (push (cons start eol) spans))
+      (nreverse spans))))
+
+(defun M2-simple-doc--prose-spans (bounds from to)
+  "Return the stretches of prose between FROM and TO.
+BOUNDS is the extent of the SimpleDoc string they lie in.
+
+Which lines are prose can only be told from the sections above them, so
+the string is read from its beginning however small the region; but the
+stretches themselves are worked out for the region alone, and the reading
+stops at its end.  Doing it for the whole string instead cost a thousand
+lines of needless work on every keystroke in a long docstring."
+  (let ((spans nil)
+        (limit (min to (M2-simple-doc--text-end (cdr bounds)))))
+    (M2-simple-doc--walk
+     (car bounds) limit
+     (lambda (_indent keyword stack)
+       ;; A keyword line names a section; it is already marked up as the
+       ;; Macaulay2 symbol it also is, which reads well enough.
+       (unless keyword
+         (when (and (>= (line-end-position) from)
+                    (M2-simple-doc--prose-line-p stack))
+           (push (M2-simple-doc--line-spans) spans)))))
+    (apply #'nconc (nreverse spans))))
+
+(defvar-local M2-simple-doc--spans-cache nil
+  "Memo for `M2-simple-doc--prose-spans'.
+A cons of a key describing one region of one docstring and the stretches
+of prose in it.  Font lock asks for these repeatedly as it works through
+a region, and answering means reading the docstring down to it.")
+
+(defun M2-simple-doc--cached-prose-spans (bounds from to)
+  "Return the stretches of prose between FROM and TO in the string BOUNDS.
+The key deliberately leaves FROM out.  Font lock works through a region
+by calling the matcher again and again with the point further along and
+the same limit, so keying on the point would miss every time and read the
+docstring afresh at every call; the stretches found for the first call
+cover the whole of that region, and serve for the rest of them."
+  (let ((key (list (car bounds) (cdr bounds) to (buffer-chars-modified-tick))))
+    (unless (equal (car M2-simple-doc--spans-cache) key)
+      (setq M2-simple-doc--spans-cache
+            (cons key (M2-simple-doc--prose-spans bounds from to))))
+    (cdr M2-simple-doc--spans-cache)))
+
+(defun M2-simple-doc--opener-regexp ()
+  "Return a regexp matching the /// that opens a SimpleDoc string."
+  (concat "\\_<" (regexp-opt M2-simple-doc-string-openers) "[ \t]*///"))
+
+(defun M2-simple-doc-fontify-prose (limit)
+  "Font-lock matcher for the prose of a SimpleDoc string.
+Set the match data to the next stretch of prose between point and LIMIT
+and move over it, or return nil when there is none.  A stretch stops at
+the end of its line and at either end of an @...@ block, so that the
+Macaulay2 expression in one keeps the markup the rest of
+`M2-mode-font-lock-keywords' gave it."
+  (let ((found nil)
+        (start (point))
+        (opener (M2-simple-doc--opener-regexp)))
+    (while (and (not found) (< (point) limit))
+      (let ((bounds (M2-inside-simple-doc-p (point))))
+        (if (null bounds)
+            (unless (re-search-forward opener limit t)
+              (goto-char limit))
+          (let* ((spans (M2-simple-doc--cached-prose-spans bounds start limit))
+                 (span (cl-find-if (lambda (s) (> (cdr s) (point))) spans)))
+            (if (and span (< (car span) limit))
+                (let ((beg (max (car span) (point)))
+                      (end (min (cdr span) limit)))
+                  (set-match-data (list beg end))
+                  (goto-char (max end (1+ (point))))
+                  (setq found t))
+              ;; Nothing more in this string: step past it.
+              (goto-char (max (1+ (point)) (min limit (cdr bounds)))))))))
+    found))
 
 (provide 'M2-simple-doc)
 

--- a/M2.el
+++ b/M2.el
@@ -50,13 +50,9 @@
   :type 'integer
   :group 'M2)
 
-(defcustom M2-simple-doc-indent-level 2
-  "Indentation increment inside a SimpleDoc string.
-SimpleDoc is customarily written in steps of two, and being a language
-of its own it is indented by TAB alone rather than computed.  See
-`M2-simple-doc-string-openers'."
-  :type 'integer
-  :group 'M2)
+;; Required after the group it adds to is defined, and before anything
+;; below uses `M2-simple-doc-string-openers'.
+(require 'M2-simple-doc)
 
 ;;; SMIE (Simple Minded Indentation Engine)
 
@@ -334,6 +330,13 @@ comment."
           ;; Otherwise the contents line up with whatever follows it.
           (1+ (current-column)))))))
 
+(defvar M2-smie--top-level-column 0
+  "The column at which a statement at the outermost level begins.
+Zero in a buffer of Macaulay2, but not in an `Example' or `Code' section
+of a SimpleDoc string, whose code is a whole block indented by the
+section around it.  `M2-simple-doc--smie-column' binds this while it runs
+the engine over such a body.")
+
 (defun M2-smie-rules (kind token)
   "Macaulay2 indentation rules for Simple Minded Indentation Engine.
 KIND is a keyword such as `:before', `:after', or `:elem', and TOKEN
@@ -364,12 +367,13 @@ is the token string at the relevant position."
             ;; Inside a bracket SMIE did not report as the parent, or could
             ;; not measure.
             (column (cons 'column column))
-            ;; No enclosing bracket at all: a top-level statement, at column
-            ;; 0.  This has to be an absolute column rather than an offset of
-            ;; 0, which would be measured from the separator's own column ---
-            ;; and for a newline ending a commented line that is the column
-            ;; the comment ran out to.
-            ((null (nth 1 (syntax-ppss))) '(column . 0))))))))
+            ;; No enclosing bracket at all: a top-level statement, at the
+            ;; outermost column.  This has to be an absolute column rather
+            ;; than an offset of 0, which would be measured from the
+            ;; separator's own column --- and for a newline ending a
+            ;; commented line that is the column the comment ran out to.
+            ((null (nth 1 (syntax-ppss)))
+             (cons 'column M2-smie--top-level-column))))))))
 
 (defcustom M2-smie-blink-max-distance 3000
   "How far SMIE may scan to find a matching block, in characters.
@@ -1071,19 +1075,6 @@ indented as code."
   :type '(repeat string)
   :group 'M2)
 
-(defcustom M2-simple-doc-string-openers '("doc" "document" "multidoc")
-  "Words introducing a ///.../// string written in SimpleDoc.
-The contents are fontified as Macaulay2 --- SimpleDoc quotes Macaulay2
-code freely, and its prose reads better with the operators and types
-marked up --- but they are not indented, since SimpleDoc is a language of
-its own that this mode does not understand.
-
-Any delimiter left unbalanced inside such a string is demoted to
-punctuation, so that prose cannot disturb the code that follows it.
-A ///.../// with any other word in front of it is simply a string."
-  :type '(repeat string)
-  :group 'M2)
-
 (defun M2--raw-string-terminator (start limit)
   "Return the bounds of the /// closing a raw string with its body at START.
 The value is a cons of the position of the closing /// and the position
@@ -1210,6 +1201,25 @@ indented as code."
          (>= pos (+ open 3))
          (not (member (M2--raw-string-opener open) M2-code-string-openers)))))
 
+(defun M2-inside-simple-doc-p (&optional pos)
+  "Return the bounds of the SimpleDoc string containing POS, or nil.
+The value is a cons of the first position after the opening /// and the
+position of the closing ///, or of `point-max' while the string is still
+unterminated.
+
+Unlike `M2-inside-non-code-string-p' this is true only of the strings
+introduced by a word in `M2-simple-doc-string-openers'.  A plain
+///.../// is raw text with no language in it, and is left alone."
+  (setq pos (or pos (point)))
+  (syntax-propertize (min (point-max) (1+ pos)))
+  (let* ((probe (if (and (= pos (point-max)) (> pos (point-min))) (1- pos) pos))
+         (open (get-text-property probe 'M2-raw-string)))
+    (when (and open
+               (>= pos (+ open 3))
+               (member (M2--raw-string-opener open) M2-simple-doc-string-openers))
+      (let ((close (M2--raw-string-terminator (+ open 3) (point-max))))
+        (cons (+ open 3) (if close (car close) (point-max)))))))
+
 (defun M2-blank-line ()
   "Determine whether the line is blank."
      (save-excursion (beginning-of-line) (skip-chars-forward " \t") (eolp)))
@@ -1237,43 +1247,61 @@ indented as code."
 
 (defun M2-electric-tab ()
   "`indent-line-function' for Macaulay2.
-If called by a command in `M2-insert-tab-commands' with the point to the
-right of non-whitespace characters in the same line, insert
-`M2-indent-level' spaces.  Inside a ///.../// string that does not hold
-Macaulay2 code, follow the previous line when asked for an indentation
-explicitly and otherwise leave the line alone.  Everywhere else, use SMIE."
+Inside a `doc' string, use the SimpleDoc engine, wherever the point may
+be in the line.  Otherwise, if called by a command in
+`M2-insert-tab-commands' with the point to the right of non-whitespace
+characters in the same line, insert `M2-indent-level' spaces.  Inside any
+other ///.../// string that does not hold Macaulay2 code, follow the
+previous line when asked for an indentation explicitly and otherwise
+leave the line alone.  Everywhere else, use SMIE."
   (interactive)
-  (cond
-   ((and (memq this-command M2-insert-tab-commands)
-         (not (M2-in-front)))
-    (indent-to
-     (prog1 (+ (current-column) M2-indent-level)
-       (delete-horizontal-space))))
-   ;; `doc' strings are SimpleDoc, a language of its own that this mode does
-   ;; not understand, and the rest are raw text.  SMIE would flatten both, so
-   ;; keep out: return `noindent' for anything that reindents in bulk ---
-   ;; `indent-region' and `electric-indent-mode' both leave such a line
-   ;; untouched --- and follow the previous line when TAB is pressed.
-   ((M2-inside-non-code-string-p)
+  (let* ((bounds (M2-inside-simple-doc-p))
+         ;; A tab was asked for by hand, at a place in the line where one
+         ;; could be inserted rather than the line indented.
+         (tab-wanted (and (memq this-command M2-insert-tab-commands)
+                          (not (M2-in-front))))
+         ;; A `doc' string is SimpleDoc, which has an engine of its own.
+         ;; It is asked first, and asked even with the point in the middle
+         ;; of the line: a line is typed from the left margin rightwards,
+         ;; so the moment one most wants TAB to indent it is the moment the
+         ;; point is at the end of what was just typed --- which is exactly
+         ;; when the tab below would instead push spaces in at the point.
+         ;; The answer is a column, or `noindent' where SimpleDoc has
+         ;; nothing to say about the line, or nil where this is not a
+         ;; SimpleDoc string at all.
+         (done (and bounds (M2-simple-doc-indent-line bounds))))
     (cond
-     ;; An explicit TAB takes the line one step further in.  Aligning with
-     ;; the line above, as `fundamental-mode' does, reads badly in SimpleDoc,
-     ;; whose nesting is what carries the meaning.
-     ((memq this-command M2-insert-tab-commands)
-      (indent-line-to (+ (current-indentation) M2-simple-doc-indent-level)))
-     ;; A line with nothing on it at all has nothing to lose, so carry the
-     ;; previous line's indentation over to it; this is what makes RET
-     ;; continue at the right level.  A line that is blank but not empty
-     ;; keeps its whitespace, which may well be significant to SimpleDoc.
-     ((save-excursion (beginning-of-line) (eolp))
-      (indent-line-to
-       (save-excursion
-         (forward-line 0)
-         (skip-chars-backward " \t\n")
-         (current-indentation))))
-     ;; Anything else, `indent-region' most of all, leaves the line alone.
-     (t 'noindent)))
-   (t (smie-indent-line))))
+     ;; Where SimpleDoc declined and a tab was asked for --- in a `Pre'
+     ;; body, whose indentation is its content --- the tab is still owed.
+     ((and done (not (and tab-wanted (eq done 'noindent)))) done)
+     (tab-wanted
+      (indent-to
+       (prog1 (+ (current-column) M2-indent-level)
+         (delete-horizontal-space))))
+     ;; Any other ///.../// is raw text.  SMIE would flatten it, so keep
+     ;; out: return `noindent' for anything that reindents in bulk ---
+     ;; `indent-region' and `electric-indent-mode' both leave such a line
+     ;; untouched --- and follow the previous line when TAB is pressed.
+     ((M2-inside-non-code-string-p)
+      (cond
+       ;; An explicit TAB takes the line one step further in.  Aligning
+       ;; with the line above, as `fundamental-mode' does, tells the writer
+       ;; of a raw string nothing they did not already have.
+       ((memq this-command M2-insert-tab-commands)
+        (indent-line-to (+ (current-indentation) M2-indent-level)))
+       ;; A line with nothing on it at all has nothing to lose, so carry
+       ;; the previous line's indentation over to it; this is what makes
+       ;; RET continue at the right level.  A line that is blank but not
+       ;; empty keeps its whitespace, which may matter to the string.
+       ((save-excursion (beginning-of-line) (eolp))
+        (indent-line-to
+         (save-excursion
+           (forward-line 0)
+           (skip-chars-backward " \t\n")
+           (current-indentation))))
+       ;; Anything else, `indent-region' most of all, leaves the line be.
+       (t 'noindent)))
+     (t (smie-indent-line)))))
 
 ;;; "blink" evaluated region (heavily inspired by ESS)
 

--- a/M2.el
+++ b/M2.el
@@ -526,7 +526,11 @@ characters of point."
    (cons M2-symbols-keyword-regexp  'font-lock-keyword-face)
    (cons M2-symbols-type-regexp     'font-lock-type-face)
    (cons M2-symbols-function-regexp 'font-lock-function-name-face)
-   (cons M2-symbols-constant-regexp 'font-lock-constant-face)))
+   (cons M2-symbols-constant-regexp 'font-lock-constant-face)
+   ;; The prose of a doc string is not Macaulay2, and the words it is made
+   ;; of collide with the tables above.  Painted last, and over whatever
+   ;; they made of it, but never over an @...@ block.
+   (list #'M2-simple-doc-fontify-prose '(0 'font-lock-doc-face t))))
 
 ; TODO:
 ; font-lock-warning-face

--- a/M2.el
+++ b/M2.el
@@ -35,13 +35,368 @@
 
 (require 'font-lock)
 (require 'comint)
+(require 'smie)
 (require 'thingatpt)
 (require 'M2-symbols)
+(require 'M2-operators)
 
 (defgroup M2 nil
   "Support for Macaulay2 language development."
   :group 'languages
   :prefix "M2-")
+
+(defcustom M2-indent-level 4
+  "Indentation increment in Macaulay2 mode."
+  :type 'integer
+  :group 'M2)
+
+(defcustom M2-simple-doc-indent-level 2
+  "Indentation increment inside a SimpleDoc string.
+SimpleDoc is customarily written in steps of two, and being a language
+of its own it is indented by TAB alone rather than computed.  See
+`M2-simple-doc-string-openers'."
+  :type 'integer
+  :group 'M2)
+
+;;; SMIE (Simple Minded Indentation Engine)
+
+;; The operator tables come from M2-operators.el, which is generated from the
+;; parsing tables of Macaulay2 itself; see generate-operators.m2.
+
+(eval-and-compile
+
+  (defconst M2-smie--block-keywords
+    '("if" "then" "else" "try" "except" "while" "for" "new"
+      "do" "list" "of" "from" "in" "to" "when")
+    "Macaulay2 keywords that introduce or continue a block expression.")
+
+  (defconst M2-smie--operators
+    ;; "///" is here so that a doc or TEST string delimiter lexes as one
+    ;; token rather than as the quotient operators // and /.  Its contents
+    ;; are deliberately left as ordinary code, not marked as a string.
+    (let ((ops (append M2-operators-postfix '("<|" "|>" ";" "///"))))
+      (dolist (row M2-operators-binary)
+        (dolist (op (cdr row))
+          ;; The word operators (and, or, xor) are lexed as words.
+          (unless (string-match-p "\\`[[:alpha:]]" op)
+            (push op ops))))
+      (delete-dups ops))
+    "Every Macaulay2 operator spelled with punctuation.")
+
+  (defconst M2-smie--operator-regexp (regexp-opt M2-smie--operators)
+    "Regexp matching the longest Macaulay2 operator at point.")
+
+  (defconst M2-smie--continuation-tokens
+    (let ((toks (append M2-smie--block-keywords
+                        '("(" "[" "{" "<|" "and" "or" "xor" "not"
+                          ;; `quote' expressions: an identifier must follow.
+                          "symbol" "global" "local"
+                          "threadLocal" "threadVariable"))))
+      (dolist (row M2-operators-binary)
+        (dolist (op (cdr row)) (push op toks)))
+      (delete-dups toks))
+    "Tokens after which a newline continues the current statement.
+Every binary and prefix operator qualifies, since a right operand is still
+expected.  Postfix operators do not, and neither do the prefix control-flow
+words (`return', `break', `continue', ...): each of those can legitimately
+be the last thing on a line."))
+
+(defconst M2-smie-grammar
+  (eval-when-compile
+    (smie-prec2->grammar
+     (smie-merge-prec2s
+      (smie-bnf->prec2
+       ;; Every slot but the final body uses BEXP, which admits only
+       ;; bracketed expressions.  With EXP throughout, `smie-bnf->prec2'
+       ;; relates every pair of inner keywords in both directions at once
+       ;; (each is both preceded by EXP and a member of its last-ops), and
+       ;; `smie-prec2->grammar' then reports an unresolvable precedence
+       ;; cycle such as "then < in < then".  Resolvers cannot help: they
+       ;; only apply where a conflict already exists.  Final bodies stay
+       ;; EXP, so `else if' chains and do/from bodies remain exact.
+       '((bexp ("(" exps ")") ("[" exps "]") ("{" exps "}") ("<|" exps "|>"))
+         (exp (bexp)
+              ("if"  bexp "then" exp)
+              ("if"  bexp "then" bexp "else" exp)
+              ("try" bexp "then" exp)
+              ("try" bexp "then" bexp "else" exp)
+              ("try" bexp "else" exp)
+              ("try" bexp "then" bexp "except" bexp "do" exp)
+              ("try" bexp "except" bexp "do" exp)
+              ("while" bexp "do" exp)
+              ("while" bexp "list" exp)
+              ("while" bexp "list" bexp "do" exp)
+              ("for" bexp "in" bexp "do" exp)
+              ("for" bexp "in" bexp "list" exp)
+              ("for" bexp "in" bexp "list" bexp "do" exp)
+              ("for" bexp "in" bexp "when" bexp "list" bexp "do" exp)
+              ("for" bexp "from" bexp "do" exp)
+              ("for" bexp "from" bexp "to" bexp "when" bexp "do" exp)
+              ("for" bexp "from" bexp "list" bexp "do" exp)
+              ("for" bexp "to" bexp "do" exp)
+              ("for" bexp "to" bexp "list" exp)
+              ("for" bexp "when" bexp "do" exp)
+              ("for" bexp "do" exp)
+              ("for" bexp "list" bexp "do" exp)
+              ("new" bexp "of" exp)
+              ("new" bexp "from" exp)
+              ("new" bexp "of" bexp "from" exp))
+         (exps (exps ";" exps) (exps "," exps) (exp)))
+       '((assoc ";")) '("," > ",") '(";" < ",") '("," > ";"))
+      (smie-precs->prec2 M2-operators-binary))))
+  "Macaulay2 grammar table for Simple Minded Indentation Engine.")
+
+(defsubst M2-smie--comment-start-p (pos)
+  "Return non-nil if a comment can begin at POS.
+`M2-syntax-propertize-function' clears the comment flags from -- inside
+comint output blocks, so ask the syntax table rather than just matching
+the characters."
+  ;; Bit 16 of a raw syntax descriptor is the \"1\" flag: this character can
+  ;; be the first of a two-character comment opener.
+  (let ((syntax (car (syntax-after pos))))
+    (and syntax (/= 0 (logand syntax (ash 1 16))))))
+
+(defsubst M2-smie--string-delimiter-p (pos)
+  "Return non-nil if the character at POS is a string delimiter.
+Unlike `char-syntax', this honors `syntax-table' text properties.  Note
+that ///.../// is not a string as far as Macaulay2 mode is concerned."
+  ;; 7 is the string-quote class, 15 the generic-string-fence class.
+  (memq (syntax-class (syntax-after pos)) '(7 15)))
+
+(defvar-local M2-smie--separator-cache nil
+  "Memo for `M2-smie--newline-separator-p'.
+A cons of a key describing the buffer state and a hash table mapping the
+position of a newline to whether it separates two statements.  The key
+covers the accessible portion as well as the chars-modified-tick, since
+`M2-smie--matching-block-data' runs the lexer narrowed and the answer
+near the edge of a restriction differs from the unrestricted one.")
+
+(defun M2-smie--newline-separator-p ()
+  "Return non-nil if the newline at point ends a statement.
+Point must be on the newline.  The newline separates two statements unless
+the last real token before it still expects a right operand, that is, unless
+it is one of `M2-smie--continuation-tokens'.
+
+The answer is memoized, because SMIE asks it once for every newline it
+crosses and answering it means scanning back over comments and blank lines."
+  (let ((key (list (buffer-chars-modified-tick) (point-min) (point-max)))
+        (pos (point)))
+    (unless (equal (car M2-smie--separator-cache) key)
+      (setq M2-smie--separator-cache (cons key (make-hash-table :test #'eq))))
+    (let* ((cache (cdr M2-smie--separator-cache))
+           (hit (gethash pos cache 'M2-smie--miss)))
+      (if (not (eq hit 'M2-smie--miss))
+          hit
+        (puthash pos
+                 (save-excursion
+                   ;; Step past the newline first, so that `forward-comment'
+                   ;; can treat it as the end of a -- comment on this line.
+                   (forward-char 1)
+                   (forward-comment (- (point)))
+                   (skip-chars-backward " \t")
+                   (not (member (M2-smie--backward-op-token)
+                                M2-smie--continuation-tokens)))
+                 cache)))))
+
+(defun M2-smie-forward-token ()
+  "Return the Macaulay2 token after point, moving over it.
+A newline is reported as a virtual \";\" when it separates two statements,
+and skipped otherwise.  String literals are left alone: returning an empty
+token without moving is how a SMIE lexer asks the engine to step over
+whatever is at point itself."
+  (catch 'M2-smie--token
+    (while t
+      (skip-chars-forward " \t")
+      (cond
+       ((eobp) (throw 'M2-smie--token ""))
+       ;; Stop a -- comment at the newline rather than stepping over it, so
+       ;; the newline can still be seen as a statement separator.
+       ((and (looking-at-p "--") (M2-smie--comment-start-p (point)))
+        (end-of-line))
+       ;; An unterminated -* is a state every block comment passes through
+       ;; while it is being typed, and `forward-comment' declines to move
+       ;; over one; without the fallback this loop would never end.
+       ((and (looking-at-p "-\\*") (M2-smie--comment-start-p (point)))
+        (unless (forward-comment 1) (goto-char (point-max))))
+       ((eolp)
+        (if (M2-smie--newline-separator-p)
+            (progn (forward-char 1) (throw 'M2-smie--token ";"))
+          (forward-char 1)))
+       ((M2-smie--string-delimiter-p (point))
+        (throw 'M2-smie--token ""))
+       ((looking-at M2-smie--operator-regexp)
+        (goto-char (match-end 0))
+        (throw 'M2-smie--token (match-string-no-properties 0)))
+       (t
+        (let ((beg (point)))
+          (skip-syntax-forward "w_'")
+          (when (and (= beg (point))
+                     (not (memq (char-syntax (char-after)) '(?\( ?\)))))
+            ;; Not a word, an operator, a bracket or a string.  Consume it
+            ;; anyway: an empty token means "SMIE, step over this yourself",
+            ;; and SMIE can only do that for brackets and strings --- for
+            ;; anything else it gives up with "Bumped into unknown token".
+            (forward-char 1))
+          (throw 'M2-smie--token
+                 (buffer-substring-no-properties beg (point)))))))))
+
+(defun M2-smie--backward-op-token ()
+  "Return the operator or word ending at point, moving to its start."
+  (let ((end (point)))
+    (cond
+     ;; A string delimiter, which SMIE steps over itself.  Checked before the
+     ;; operator run below, since the / of a closing /// would otherwise read
+     ;; as the division operator and make the newline after it look like a
+     ;; continuation of the statement.
+     ((and (> end (point-min)) (M2-smie--string-delimiter-p (1- end))) "")
+     ;; A word, a number, or one of the word operators.
+     ((< (skip-syntax-backward "w_'") 0)
+      (buffer-substring-no-properties (point) end))
+     ;; A run of operator characters.  Rather than try to recognize an
+     ;; operator right-to-left, re-lex the run forward with the same regexp
+     ;; `M2-smie-forward-token' uses and keep the token that reaches END.
+     ;; The two directions then agree by construction, which is what SMIE
+     ;; requires of them.  ("\\" is here because M2's syntax table gives
+     ;; backslash escape syntax, to fontify "a\"b" correctly.)
+     ((< (skip-syntax-backward ".\\") 0)
+      (let (beg tok)
+        (while (< (point) end)
+          (setq beg (point))
+          (setq tok (if (looking-at M2-smie--operator-regexp)
+                        (progn (goto-char (match-end 0))
+                               (match-string-no-properties 0))
+                      (forward-char 1)
+                      (buffer-substring-no-properties beg (point)))))
+        (goto-char beg)
+        tok))
+     ;; A bracket, which SMIE steps over itself given an empty token.
+     ((or (bobp) (memq (char-syntax (char-before)) '(?\( ?\)))) "")
+     ;; Anything else: consume one character, as the forward lexer does.
+     (t (backward-char 1)
+        (buffer-substring-no-properties (point) end)))))
+
+(defun M2-smie-backward-token ()
+  "Return the Macaulay2 token before point, moving to its start.
+The exact inverse of `M2-smie-forward-token'."
+  (catch 'M2-smie--token
+    (while t
+      ;; Horizontal whitespace only: `forward-comment' would swallow the
+      ;; newline before we get a chance to report it as a separator.
+      (skip-chars-backward " \t")
+      (cond
+       ((bobp) (throw 'M2-smie--token ""))
+       ((eq (char-before) ?\n)
+        (backward-char)
+        (if (M2-smie--newline-separator-p)
+            ;; Leave point on the newline: that is where the virtual ";" is.
+            (throw 'M2-smie--token ";")
+          ;; Not a separator.  Step back over the newline, and over any
+          ;; comment or blank lines before it, then keep looking.
+          (forward-char 1)
+          (forward-comment (- (point)))))
+       ((M2-smie--string-delimiter-p (1- (point)))
+        (throw 'M2-smie--token ""))
+       (t (throw 'M2-smie--token (M2-smie--backward-op-token)))))))
+
+(defun M2-smie--block-keyword-p (token)
+  "Return non-nil if TOKEN is one of `M2-smie--block-keywords'."
+  (and (stringp token) (member token M2-smie--block-keywords)))
+
+(defun M2-smie--bracket-indentation ()
+  "Return the column for a line inside the innermost enclosing bracket.
+Return nil at top level.  This is what `smie-rule-parent' computes when
+SMIE has identified the bracket as the parent, but it does not always:
+when a separator follows its opening bracket across a comment, SMIE loses
+track of the bracket and would otherwise line the statement up with the
+comment."
+  (let ((open (nth 1 (syntax-ppss))))
+    (when open
+      (save-excursion
+        (goto-char open)
+        (if (save-excursion (forward-char 1)
+                            (skip-chars-forward " \t")
+                            ;; A comment after the bracket still leaves it
+                            ;; hanging; without this the contents line up
+                            ;; with the comment, which is the very thing
+                            ;; this function exists to avoid.
+                            (or (eolp) (M2-smie--comment-start-p (point))))
+            ;; A bracket left hanging indents its contents relative to where
+            ;; the bracket itself would go, which is not always the start of
+            ;; the line it is on: in "b) else (" the bracket belongs to the
+            ;; "if" further up.  `smie-indent-virtual' answers `noindent'
+            ;; rather than a column when it lands in a comment or a string,
+            ;; and SMIE's own rules signal when they try to do arithmetic on
+            ;; that; fall back to the bracket's own line either way.
+            (let ((virtual (condition-case nil (smie-indent-virtual)
+                             (error nil))))
+              (+ (if (numberp virtual) virtual (current-indentation))
+                 M2-indent-level))
+          ;; Otherwise the contents line up with whatever follows it.
+          (1+ (current-column)))))))
+
+(defun M2-smie-rules (kind token)
+  "Macaulay2 indentation rules for Simple Minded Indentation Engine.
+KIND is a keyword such as `:before', `:after', or `:elem', and TOKEN
+is the token string at the relevant position."
+  (pcase (cons kind token)
+    ('(:elem . basic) M2-indent-level)
+    ('(:elem . args)  M2-indent-level)
+    ;; A bracket left hanging at the end of a line indents its contents
+    ;; relative to the line that opens it, not to its own column.
+    (`(:before . ,(or "(" "[" "{" "<|"))
+     (when (smie-rule-hanging-p) (smie-rule-parent)))
+    ;; The body of a block keyword.
+    (`(:after . ,(pred M2-smie--block-keyword-p)) M2-indent-level)
+    ;; A block keyword continued on a line of its own lines up with its opener.
+    (`(:before . ,(pred M2-smie--block-keyword-p))
+     (and (not (smie-rule-bolp)) (smie-rule-parent 0)))
+    ;; Statement and sequence separators: one step in from the enclosing
+    ;; bracket, or column 0 at top level.
+    (`(,(or :before :after) . ,(or ";" ","))
+     (or (and (smie-rule-parent-p "(" "[" "{" "<|")
+              ;; `smie-rule-parent' adds the offset to the parent's virtual
+              ;; indentation, and signals when that comes back `noindent'
+              ;; because the parent sits next to a comment.
+              (condition-case nil (smie-rule-parent M2-indent-level)
+                (error nil)))
+         (let ((column (M2-smie--bracket-indentation)))
+           (cond
+            ;; Inside a bracket SMIE did not report as the parent, or could
+            ;; not measure.
+            (column (cons 'column column))
+            ;; No enclosing bracket at all: a top-level statement, at column
+            ;; 0.  This has to be an absolute column rather than an offset of
+            ;; 0, which would be measured from the separator's own column ---
+            ;; and for a newline ending a commented line that is the column
+            ;; the comment ran out to.
+            ((null (nth 1 (syntax-ppss))) '(column . 0))))))))
+
+(defcustom M2-smie-blink-max-distance 3000
+  "How far SMIE may scan to find a matching block, in characters.
+`show-paren-mode' runs on an idle timer after every cursor motion, and
+SMIE's block matching walks the buffer through the lexer, so an unbounded
+search makes cursor motion visibly slow in large files."
+  :type 'integer
+  :group 'M2)
+
+(defun M2-smie--matching-block-data (orig &rest args)
+  "Bounded replacement for `smie--matching-block-data'.
+Real brackets are handed straight to ORIG, called with ARGS, since the
+syntax table matches those far more cheaply than SMIE can.  For block
+keywords SMIE is asked, but only within `M2-smie-blink-max-distance'
+characters of point."
+  (if (or (memq (char-syntax (or (char-after) ?\s)) '(?\( ?\)))
+          (memq (char-syntax (or (char-before) ?\s)) '(?\( ?\))))
+      (apply orig args)
+    (or (save-restriction
+          (narrow-to-region
+           (max (point-min) (- (point) M2-smie-blink-max-distance))
+           (min (point-max) (+ (point) M2-smie-blink-max-distance)))
+          ;; Pass `ignore' as ORIG so that a miss inside the narrowing comes
+          ;; back as nil rather than as the default matcher's answer, which
+          ;; would be computed against the restricted buffer.
+          (ignore-errors (apply #'smie--matching-block-data #'ignore args)))
+        (apply orig args))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; key bindings
@@ -101,11 +456,6 @@
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.m2\\'" . M2-mode))
-
-(defcustom M2-indent-level 4
-  "Indentation increment in Macaulay2 mode."
-  :type 'integer
-  :group 'M2)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; M2-comint-mode
@@ -204,12 +554,24 @@ This relies on `comint-mode` tagging output with the `field` text property."
   (set (make-local-variable 'comment-start-skip) "-- *")
   (set (make-local-variable 'comint-input-autoexpand) nil)
   (set (make-local-variable 'transient-mark-mode) t)
+  (smie-setup M2-smie-grammar #'M2-smie-rules
+              :forward-token  #'M2-smie-forward-token
+              :backward-token #'M2-smie-backward-token)
+  ;; `smie-setup' puts its own unbounded block matcher on
+  ;; `show-paren-data-function'; swap in the bounded one.
+  (remove-function (local 'show-paren-data-function) #'smie--matching-block-data)
+  (add-function :around (local 'show-paren-data-function)
+                #'M2-smie--matching-block-data)
   (set (make-local-variable 'indent-line-function) #'M2-electric-tab)
   (setq font-lock-defaults '( M2-mode-font-lock-keywords ))
   (setq truncate-lines t)
   (setq case-fold-search nil)
   (add-hook 'completion-at-point-functions #'M2-completion-at-point nil t)
-  (setq-local syntax-propertize-function M2-syntax-propertize-function))
+  (setq-local syntax-propertize-function #'M2-syntax-propertize)
+  ;; A ///.../// spans lines, so an edit inside one has to re-propertize the
+  ;; whole string rather than the line that changed.
+  (add-hook 'syntax-propertize-extend-region-functions
+            #'syntax-propertize-multiline nil t))
 
 ;; menus
 
@@ -258,7 +620,13 @@ This relies on `comint-mode` tagging output with the `field` text property."
 
 ;; syntax
 
-; bug: ///A"B"C/// vs ///ABC///
+;; A ///.../// is not simply a string: what is written in one depends on the
+;; word in front of it, and `M2-syntax-propertize' treats the three cases
+;; differently.  A TEST string is Macaulay2 code and is left alone; a doc
+;; string is SimpleDoc, which quotes Macaulay2 freely, so it stays ordinary
+;; text with only its unbalanced delimiters demoted; anything else is a
+;; string.  Note that a syntax table cannot express the delimiter itself,
+;; since it is three characters long.
 
 (mapc
  (function
@@ -276,7 +644,15 @@ This relies on `comint-mode` tagging output with the `field` text property."
     (modify-syntax-entry ?>  "." syntax-table)
     (modify-syntax-entry ?'  "_" syntax-table) ; part of a symbol
     (modify-syntax-entry ?&  "." syntax-table)
-    (modify-syntax-entry ?|  "." syntax-table)))
+    (modify-syntax-entry ?|  "." syntax-table)
+    ;; These default to word or symbol constituents, but each is an operator
+    ;; in Macaulay2 and none of them can occur in an identifier.  Getting this
+    ;; right keeps the SMIE lexer, `forward-word' and `bounds-of-thing-at-point'
+    ;; from running an operator together with the identifier beside it.
+    (modify-syntax-entry ?/  "." syntax-table)
+    (modify-syntax-entry ?·  "." syntax-table)
+    (modify-syntax-entry ?⊠  "." syntax-table)
+    (modify-syntax-entry ?⧢  "." syntax-table)))
  (list M2-mode-syntax-table M2-comint-mode-syntax-table))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -684,25 +1060,155 @@ time we send new input to the M2 process."
      (and (eolp) (M2-next-line-blank) (= 0 (M2-paren-change))
 	 (newline nil t)))
 
-(defun M2-next-line-indent-amount ()
-  "Determine how much to indent the next line."
-     (+ (current-indentation) (* (M2-paren-change) M2-indent-level)))
-
-(defun M2-this-line-indent-amount ()
-     "Determine how much to indent the current line."
-     (save-excursion
-	  (beginning-of-line)
-	  (if (bobp)
-	      0
-	      (forward-line -1)
-	      ;; if the previous line is blank, then keep going
-	      (while (and (not (bobp)) (looking-at-p "[[:blank:]]*$"))
-		(forward-line -1))
-	      (M2-next-line-indent-amount))))
-
 (defun M2-in-front ()
   "Determine whether we are at the front of the line."
      (save-excursion (skip-chars-backward " \t") (bolp)))
+
+(defcustom M2-code-string-openers '("TEST")
+  "Words introducing a ///.../// string whose contents are Macaulay2 code.
+Such a string is left entirely alone, so its contents are fontified and
+indented as code."
+  :type '(repeat string)
+  :group 'M2)
+
+(defcustom M2-simple-doc-string-openers '("doc" "document" "multidoc")
+  "Words introducing a ///.../// string written in SimpleDoc.
+The contents are fontified as Macaulay2 --- SimpleDoc quotes Macaulay2
+code freely, and its prose reads better with the operators and types
+marked up --- but they are not indented, since SimpleDoc is a language of
+its own that this mode does not understand.
+
+Any delimiter left unbalanced inside such a string is demoted to
+punctuation, so that prose cannot disturb the code that follows it.
+A ///.../// with any other word in front of it is simply a string."
+  :type '(repeat string)
+  :group 'M2)
+
+(defun M2--raw-string-terminator (start limit)
+  "Return the bounds of the /// closing a raw string with its body at START.
+The value is a cons of the position of the closing /// and the position
+after it, or nil if the string is unterminated before LIMIT.
+
+Macaulay2 lets a raw string contain slashes by doubling them, so a run of
+slashes closes the string only when its length is odd and at least three:
+a run of four stands for a literal ///, and one of nine for /// followed
+by the terminator.  See the documentation of /// in Macaulay2."
+  (save-excursion
+    (goto-char start)
+    (catch 'found
+      (while (re-search-forward "/+" limit t)
+        (let ((n (- (match-end 0) (match-beginning 0))))
+          (when (and (>= n 3) (= 1 (mod n 2)))
+            (throw 'found (cons (- (match-end 0) 3) (match-end 0))))))
+      nil)))
+
+(defun M2--raw-string-opener (pos)
+  "Return the word introducing the raw string whose /// begins at POS."
+  (save-excursion
+    (goto-char pos)
+    (skip-chars-backward " \t")
+    (let ((end (point)))
+      (skip-chars-backward "A-Za-z0-9_'")
+      (buffer-substring-no-properties (point) end))))
+
+(defun M2--demote-unbalanced (beg end)
+  "Give punctuation syntax to unbalanced delimiters between BEG and END.
+A SimpleDoc string is ordinary buffer text as far as the parser is
+concerned, so an unmatched bracket or quote in its prose would otherwise
+run on and displace every expression after it.  Balanced ones are left
+alone, so that a string or a list written inside the prose still reads as
+one."
+  (let ((guard 0))
+    (catch 'done
+      (while (< (setq guard (1+ guard)) 100)
+        (let ((state (parse-partial-sexp beg end)))
+          (cond
+           ((nth 3 state)               ; a string is still open
+            (put-text-property (nth 8 state) (1+ (nth 8 state))
+                               'syntax-table (string-to-syntax ".")))
+           ((> (nth 0 state) 0)         ; brackets are still open
+            (dolist (open (nth 9 state))
+              (put-text-property open (1+ open)
+                                 'syntax-table (string-to-syntax "."))))
+           ((< (nth 0 state) 0)         ; more closers than openers
+            (save-excursion
+              (goto-char beg)
+              (let ((depth 0))
+                (while (< (point) end)
+                  (pcase (char-syntax (char-after))
+                    (?\( (setq depth (1+ depth)))
+                    (?\) (if (> depth 0)
+                             (setq depth (1- depth))
+                           (put-text-property (point) (1+ (point))
+                                              'syntax-table
+                                              (string-to-syntax ".")))))
+                  (forward-char 1)))))
+           (t (throw 'done t))))))))
+
+(defun M2-syntax-propertize (start end)
+  "Apply Macaulay2 syntax properties between START and END.
+Handles the ///.../// raw strings, which a syntax table cannot describe
+because their delimiter is three characters long.  How one is treated
+depends on the word in front of it: see `M2-code-string-openers' and
+`M2-simple-doc-string-openers'."
+  (funcall M2-syntax-propertize-function start end)
+  ;; A raw string reaching into START was propertized as a whole, so pick it
+  ;; up from its beginning rather than in the middle.
+  (let ((from (or (and (> start (point-min))
+                       (get-text-property (1- start) 'M2-raw-string))
+                  start)))
+    ;; `syntax-propertize' clears the syntax-table properties it manages, but
+    ;; not ours, and a stale one would keep reporting a string that is gone.
+    (remove-text-properties from end '(M2-raw-string nil))
+    (save-excursion
+      (goto-char from)
+      ;; A raw string may well run past END, and propertizing it takes point
+      ;; with it, so test before searching rather than handing
+      ;; `search-forward' a bound behind point.
+      (while (and (< (point) end) (search-forward "///" end t))
+        (let* ((open (match-beginning 0))
+               (body (match-end 0))
+               (state (save-excursion (syntax-ppss open))))
+          ;; A /// inside a comment or an ordinary string opens nothing.
+          (if (or (nth 3 state) (nth 4 state))
+              (goto-char body)
+            (let* ((close (M2--raw-string-terminator body (point-max)))
+                   (body-end (if close (car close) (point-max)))
+                   (finish (if close (cdr close) (point-max)))
+                   (opener (M2--raw-string-opener open)))
+              (unless (member opener M2-code-string-openers)
+                (if (member opener M2-simple-doc-string-openers)
+                    (M2--demote-unbalanced body body-end)
+                  ;; Anything else is just a string.  Fence off the outer
+                  ;; slash at each end; the syntax table has no way to spell
+                  ;; a three-character delimiter.
+                  (put-text-property open (1+ open) 'syntax-table
+                                     (string-to-syntax "|"))
+                  (when close
+                    (put-text-property (1- finish) finish 'syntax-table
+                                       (string-to-syntax "|")))))
+              ;; Remember the extent so that an edit inside it re-propertizes
+              ;; the whole string, not just the line that changed.
+              (put-text-property open finish 'M2-raw-string open)
+              (put-text-property open finish 'syntax-multiline t)
+              (goto-char finish))))))))
+
+(defun M2-inside-non-code-string-p (&optional pos)
+  "Return non-nil if POS is inside a ///.../// that does not hold code.
+That is, inside a SimpleDoc string or a plain one.  The opening delimiter
+itself does not count, so the line introducing the string is still
+indented as code."
+  (setq pos (or pos (point)))
+  (syntax-propertize (min (point-max) (1+ pos)))
+  (let ((open (get-text-property
+               ;; There is no character at point-max to carry the property,
+               ;; so look at the one before it; that is where the point sits
+               ;; while a string at the end of the buffer is being typed.
+               (if (and (= pos (point-max)) (> pos (point-min))) (1- pos) pos)
+               'M2-raw-string)))
+    (and open
+         (>= pos (+ open 3))
+         (not (member (M2--raw-string-opener open) M2-code-string-openers)))))
 
 (defun M2-blank-line ()
   "Determine whether the line is blank."
@@ -731,17 +1237,43 @@ time we send new input to the M2 process."
 
 (defun M2-electric-tab ()
   "`indent-line-function' for Macaulay2.
-If called by command in `M2-insert-tab-commands', and if the point is either
-to right of non-whitespace characters in the same line or if the line
-is blank, then insert `M2-indent-level' spaces.  Otherwise, indent the
-line based on the depth of the parentheses in the code."
+If called by a command in `M2-insert-tab-commands' with the point to the
+right of non-whitespace characters in the same line, insert
+`M2-indent-level' spaces.  Inside a ///.../// string that does not hold
+Macaulay2 code, follow the previous line when asked for an indentation
+explicitly and otherwise leave the line alone.  Everywhere else, use SMIE."
   (interactive)
-  (indent-to
-   (prog1 (if (and (memq this-command M2-insert-tab-commands)
-		   (or (not (M2-in-front)) (M2-blank-line)))
-	      (+ (current-column) M2-indent-level)
-	    (M2-this-line-indent-amount))
-     (delete-horizontal-space))))
+  (cond
+   ((and (memq this-command M2-insert-tab-commands)
+         (not (M2-in-front)))
+    (indent-to
+     (prog1 (+ (current-column) M2-indent-level)
+       (delete-horizontal-space))))
+   ;; `doc' strings are SimpleDoc, a language of its own that this mode does
+   ;; not understand, and the rest are raw text.  SMIE would flatten both, so
+   ;; keep out: return `noindent' for anything that reindents in bulk ---
+   ;; `indent-region' and `electric-indent-mode' both leave such a line
+   ;; untouched --- and follow the previous line when TAB is pressed.
+   ((M2-inside-non-code-string-p)
+    (cond
+     ;; An explicit TAB takes the line one step further in.  Aligning with
+     ;; the line above, as `fundamental-mode' does, reads badly in SimpleDoc,
+     ;; whose nesting is what carries the meaning.
+     ((memq this-command M2-insert-tab-commands)
+      (indent-line-to (+ (current-indentation) M2-simple-doc-indent-level)))
+     ;; A line with nothing on it at all has nothing to lose, so carry the
+     ;; previous line's indentation over to it; this is what makes RET
+     ;; continue at the right level.  A line that is blank but not empty
+     ;; keeps its whitespace, which may well be significant to SimpleDoc.
+     ((save-excursion (beginning-of-line) (eolp))
+      (indent-line-to
+       (save-excursion
+         (forward-line 0)
+         (skip-chars-backward " \t\n")
+         (current-indentation))))
+     ;; Anything else, `indent-region' most of all, leaves the line alone.
+     (t 'noindent)))
+   (t (smie-indent-line))))
 
 ;;; "blink" evaluated region (heavily inspired by ESS)
 

--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,9 @@ all:
 update-symbols:
 	$(M2) --script generate-symbols.m2
 
-.PHONY: all update-symbols
+update-operators:
+	$(M2) --script generate-operators.m2
+
+update: update-symbols update-operators
+
+.PHONY: all update update-symbols update-operators

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Emacs Package for Macaulay2
 
 To get started with running Macaulay2 with Emacs, look at the file `M2-emacs-help.txt`, which is a text version of the documentation node available via `help "running Macaulay2 in emacs"`. To learn how to edit a file with Macaulay2 code in it using Emacs, see the file `M2-emacs.m2`, which is a text version of the documentation node available via `help "editing Macaulay2 code with emacs"`.
 
-The files `M2.el` and `M2-mode.el` provide modes for editing Macaulay2 source in Emacs and running a Macaulay2 session within an Emacs buffer. The syntax highlighting symbols are defined in `M2-symbols.el`.
+The files `M2.el` and `M2-mode.el` provide modes for editing Macaulay2 source in Emacs and running a Macaulay2 session within an Emacs buffer. The syntax highlighting symbols are defined in `M2-symbols.el` and the operator precedence table used for indentation in `M2-operators.el`; both are generated from Macaulay2 itself by `make update`. `M2-simple-doc.el` handles the SimpleDoc language written inside `doc /// ... ///` strings.
 
 ## Installation
 

--- a/generate-operators.m2
+++ b/generate-operators.m2
@@ -1,0 +1,73 @@
+-- Regenerate M2-operators.el from the parsing tables of the running
+-- Macaulay2.  Run "make update-operators".
+--
+-- The Style package's generateGrammar has no placeholder for operators, so
+-- the substitution is done here rather than there.
+
+debug Core -- for getParsing
+
+-- getParsing returns {precedence, binaryStrength, unaryStrength}, with a
+-- strength of -1 where the operator has no such form.  binding.d gives a
+-- binary operator the strength of its precedence when it is left
+-- associative, and one less when it is right associative.
+parsing = new HashTable from apply(
+    select(values Core.Dictionary, s -> instance(value s, Keyword)),
+    s -> toString s => getParsing s)
+
+opPrecedence = op -> (parsing#op)#0
+binaryStrength = op -> (parsing#op)#1
+unaryStrength = op -> (parsing#op)#2
+isBinary = op -> binaryStrength op != -1
+isLeftAssociative = op -> binaryStrength op == opPrecedence op
+
+-- SPACE is adjacency, which has no symbol to match, and ";" separates
+-- statements, which M2-smie-grammar describes with a production of its own.
+binaryOperators = sort select(keys parsing,
+    op -> isBinary op and op != "SPACE" and op != ";")
+
+-- A postfix operator has neither a binary nor a unary form.  That also
+-- describes the closing delimiters, which belong to the grammar instead.
+-- (*) is left out as well: it is already balanced parentheses, so both
+-- directions of the lexer decline it and let SMIE step over it as a sexp,
+-- which is what keeps them exact inverses of one another.
+notReallyPostfix = set {")", "]", "}", "|>", "(*)"}
+postfixOperators = sort select(keys parsing,
+    op -> not isBinary op and unaryStrength op == -1
+    and not notReallyPostfix#?op)
+
+-- smie-precs->prec2 wants the loosest level first, and one associativity per
+-- row.  Macaulay2 has one level of mixed associativity, the multiplicative
+-- one holding both / and \, so split such a level in two.  Listing the
+-- right associative half first is what the language grammar does, and is
+-- observationally equivalent, since a right associative operator binds its
+-- right operand one level down in any case.
+-- Within a row smie-prec2->grammar hands each operator a distinct level
+-- descending from the first rather than the shared one its docstring
+-- describes, but the relations it derives them from are the same whatever
+-- the order, and re-indenting Macaulay2's own sources gives identical output
+-- either way.  Sort so that the generated file is reproducible.
+row = (assoc, ops) -> concatenate("(", assoc, " ", demark(" ", format \ sort ops), ")")
+
+levels = apply(sort unique apply(binaryOperators, opPrecedence), p -> (
+	ops := select(binaryOperators, op -> opPrecedence op == p);
+	rights := select(ops, op -> not isLeftAssociative op);
+	lefts := select(ops, isLeftAssociative);
+	rows := {};
+	if #rights > 0 then rows = append(rows, row("right", rights));
+	if #lefts > 0 then rows = append(rows, row("left", lefts));
+	demark("\n    ", rows)))
+
+-- replace treats a backslash in the replacement as an escape, so any that
+-- format produced have to be doubled to survive the substitution.
+protect' = s -> replace("\\\\", "\\\\\\\\", s)
+
+template = get "./M2-operators.el.in"
+bannerText = concatenate("Auto-generated for Macaulay2-", version#"VERSION",
+    ". Do not modify this file manually.")
+output = replace("@M2BANNER@", bannerText, template)
+output = replace("@M2VERSION@", version#"VERSION", output)
+output = replace("@M2BINARYOPS@", protect' demark("\n    ", levels), output)
+output = replace("@M2POSTFIXOPS@", protect' demark(" ", format \ postfixOperators), output)
+"./M2-operators.el" << output << close
+
+printerr("generated M2-operators.el for Macaulay2-", version#"VERSION")

--- a/test/M2-simple-doc-tests.el
+++ b/test/M2-simple-doc-tests.el
@@ -905,6 +905,110 @@ doc ///
     (indent-according-to-mode)
     (should (= (current-indentation) 6))))
 
+;;; Fontification.
+
+(defun M2-simple-doc-tests--face-at (text string)
+  "Return the face on the first occurrence of STRING in TEXT."
+  (with-temp-buffer
+    (insert text)
+    (M2-mode)
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (search-forward string)
+    (get-text-property (- (point) (length string)) 'face)))
+
+(ert-deftest M2-simple-doc-test-prose-is-fontified-as-documentation ()
+  "Prose is prose, though every SimpleDoc keyword is a Macaulay2 symbol too.
+Without this the headline below comes out with `Key', `Example' and
+`Text' as constants and `for' and `in' as keywords."
+  (let ((text "doc ///
+  Headline
+    a Key for the Example in the Text
+///
+"))
+    (should (eq (M2-simple-doc-tests--face-at text "a Key for the Example")
+                'font-lock-doc-face))))
+
+(ert-deftest M2-simple-doc-test-at-blocks-keep-their-markup ()
+  "The Macaulay2 in an @...@ block is left with the markup it was given."
+  (let ((text "doc ///
+  Description
+    Text
+      Use @TO Example@ to say so.
+///
+"))
+    (should (eq (M2-simple-doc-tests--face-at text "TO") 'font-lock-type-face))
+    (should (eq (M2-simple-doc-tests--face-at text "Example")
+                'font-lock-constant-face))
+    (should (eq (M2-simple-doc-tests--face-at text "Use ")
+                'font-lock-doc-face))
+    (should (eq (M2-simple-doc-tests--face-at text " to say so.")
+                'font-lock-doc-face))))
+
+(ert-deftest M2-simple-doc-test-escaped-at-sign-opens-nothing ()
+  "A \\=\\@ is a literal at sign, so the prose around it stays prose."
+  (let ((text "doc ///
+  Description
+    Text
+      write to someone\\@example.com about it
+///
+"))
+    (should (eq (M2-simple-doc-tests--face-at text "about it")
+                'font-lock-doc-face))))
+
+(ert-deftest M2-simple-doc-test-comment-marker-in-prose-is-prose ()
+  "A -- in a sentence must not comment out the rest of the line.
+The syntax table makes it a comment, and the prose rule paints over it."
+  (let ((text "doc ///
+  Description
+    Text
+      a dash -- and what follows it
+///
+"))
+    (should (eq (M2-simple-doc-tests--face-at text "and what follows it")
+                'font-lock-doc-face))))
+
+(ert-deftest M2-simple-doc-test-code-sections-keep-code-markup ()
+  "The bodies that Macaulay2 evaluates are left fontified as Macaulay2."
+  (let ((text "doc ///
+  Key
+    (resolution, Module)
+  Inputs
+    n:ZZ
+      the Number of Things
+  Description
+    Example
+      R = QQ[x]
+///
+"))
+    (should (eq (M2-simple-doc-tests--face-at text "resolution")
+                'font-lock-function-name-face))
+    ;; An item's type is evaluated, so it stays code; its description does not.
+    (should (eq (M2-simple-doc-tests--face-at text "ZZ\n") 'font-lock-type-face))
+    (should (eq (M2-simple-doc-tests--face-at text "the Number of Things")
+                'font-lock-doc-face))
+    (should (eq (M2-simple-doc-tests--face-at text "QQ") 'font-lock-type-face))
+    ;; A keyword line names a section, and is the Macaulay2 symbol it names.
+    (should (eq (M2-simple-doc-tests--face-at text "Description")
+                'font-lock-constant-face))))
+
+(ert-deftest M2-simple-doc-test-other-raw-strings-are-not-simple-doc ()
+  "Only the words in `M2-simple-doc-string-openers' introduce SimpleDoc.
+A TEST string is Macaulay2 and a plain one is text; neither is touched by
+this engine."
+  (with-temp-buffer
+    (insert "TEST ///\nR = QQ[x]\n///\n")
+    (M2-mode)
+    (goto-char (point-min))
+    (forward-line 1)
+    (should-not (M2-inside-simple-doc-p (point))))
+  (with-temp-buffer
+    (insert "TEX ///\n  whatever\n///\n")
+    (M2-mode)
+    (goto-char (point-min))
+    (forward-line 1)
+    (should-not (M2-inside-simple-doc-p (point)))))
+
 (provide 'M2-simple-doc-tests)
 
 ;;; M2-simple-doc-tests.el ends here

--- a/test/M2-simple-doc-tests.el
+++ b/test/M2-simple-doc-tests.el
@@ -1,0 +1,910 @@
+;;; M2-simple-doc-tests.el --- Tests for SimpleDoc indentation  -*- lexical-binding: t -*-
+
+;; Copyright (C) 2026 Daniel R. Grayson and Doug Torrance
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Tests for the SimpleDoc engine in M2-simple-doc.el.  Load this file and
+;; run `ert', or run them in batch the way .github/workflows/test.yml does.
+;;
+;; Note that these do not strip the indentation off first, as the tests in
+;; M2-smie-tests.el do.  SimpleDoc follows the off-side rule, so its
+;; indentation is its structure: stripping it would not pose the question
+;; harder, it would erase it.  What is asserted instead is that text
+;; already indented as it should be is left exactly as it is, and that
+;; text indented otherwise is moved to where the grammar puts it.
+
+;;; Code:
+
+(require 'ert)
+(require 'M2)
+
+(defun M2-simple-doc-tests--indent (text)
+  "Indent TEXT in `M2-mode' and return the result."
+  (with-temp-buffer
+    (insert text)
+    (M2-mode)
+    (let ((inhibit-message t))
+      (indent-region (point-min) (point-max)))
+    (buffer-string)))
+
+(defmacro M2-simple-doc-tests--deftest (name text &optional expected)
+  "Define a test NAME asserting that TEXT is indented as EXPECTED.
+EXPECTED defaults to TEXT itself, so that the usual case is the assertion
+that a docstring already indented as it should be is left alone.  The
+result is indented a second time as well, since an indentation that is
+not a fixed point would creep every time the file was touched."
+  (declare (indent 1))
+  `(ert-deftest ,name ()
+     (let ((once (M2-simple-doc-tests--indent ,text)))
+       (should (equal once ,(or expected text)))
+       (should (equal (M2-simple-doc-tests--indent once) once)))))
+
+;;; The keyword tables.
+
+(M2-simple-doc-tests--deftest M2-simple-doc-test-node-keywords
+  "doc ///
+  Key
+    (foo, ZZ)
+  Headline
+    a headline
+  Usage
+    foo n
+  Acknowledgement
+    thanks
+  Contributors
+    someone
+  References
+    a paper
+  Caveat
+    beware
+  SeeAlso
+    bar
+  SourceCode
+    (foo, ZZ)
+  Subnodes
+    baz
+///
+")
+
+(M2-simple-doc-tests--deftest M2-simple-doc-test-description-keywords
+  "doc ///
+  Description
+    Text
+      prose
+    Example
+      2+2
+    CannedExample
+      i1 : 2+2
+    Pre
+      preformatted
+    Code
+      PARA \"hi\"
+///
+")
+
+(M2-simple-doc-tests--deftest M2-simple-doc-test-consequences-keywords
+  "doc ///
+  Consequences
+    Item
+      one thing happens
+    Item
+      another does
+///
+")
+
+(defun M2-simple-doc-tests--tab (text line &optional column)
+  "Press TAB on LINE of TEXT in `M2-mode' and return the result.
+The point is put at COLUMN of that line first, or at its beginning."
+  (with-temp-buffer
+    (insert text)
+    (M2-mode)
+    (goto-char (point-min))
+    (forward-line line)
+    (forward-char (or column 0))
+    (let ((this-command 'indent-for-tab-command))
+      (indent-according-to-mode))
+    (buffer-string)))
+
+(ert-deftest M2-simple-doc-test-tab-works-where-the-point-actually-is ()
+  "TAB indents the line with the point wherever it is in it.
+A line is typed from the left margin rightwards, so when TAB is wanted
+the point is at the end of what was just typed, not at the beginning of
+the line.  Every test that moved to the beginning of the line first
+missed that `M2-electric-tab' would push in a tab's worth of spaces
+there instead, leaving the line where it was."
+  (let ((text "doc ///
+  Description
+    Example
+      x
+y
+///
+")
+        (want "doc ///
+  Description
+    Example
+      x
+      y
+///
+"))
+    ;; With the point after the `y', where it is when it has just been typed.
+    (should (equal (M2-simple-doc-tests--tab text 4 1) want))
+    ;; ...and at the beginning of the line.
+    (should (equal (M2-simple-doc-tests--tab text 4 0) want)))
+  ;; The point ends after the text, so that typing can go on.
+  (with-temp-buffer
+    (insert "doc ///\n  Description\n    Example\n      x\ny\n///\n")
+    (M2-mode)
+    (goto-char (point-min))
+    (forward-line 4)
+    (forward-char 1)
+    (let ((this-command 'indent-for-tab-command))
+      (indent-according-to-mode))
+    (should (= (current-column) 7))))
+
+(ert-deftest M2-simple-doc-test-tab-works-where-the-point-is-in-an-example ()
+  "The rule of the test above holds on the path through SMIE as well.
+`smie-indent-calculate' indents for the point, not for the line the point
+is on --- `smie-indent-line' moves to the indentation before calling it.
+Reached from `indent-line-function' it must do the same, or a
+continuation line of an example is indented only when the point happens
+to be at the front of it."
+  (let ((text "doc ///
+  Description
+    Example
+      f(a,
+        b + c)
+///
+")
+        (want "doc ///
+  Description
+    Example
+      f(a,
+           b + c)
+///
+"))
+    (dolist (column '(0 3 12))
+      (should (equal (M2-simple-doc-tests--tab text 4 column) want)))))
+
+(ert-deftest M2-simple-doc-test-tab-leaves-the-point-alone-on-a-tab-indented-line ()
+  "Where TAB changes nothing, it must not move the point either.
+Whether the point is within the indentation cannot be told by adding
+`current-indentation', a column, to `line-beginning-position', a
+position: they agree only where the line is indented with spaces, and a
+good third of Macaulay2's docstrings are indented with tabs."
+  (with-temp-buffer
+    (insert "doc ///\n\tKey\n\t\tbarbaz\n///\n")
+    (M2-mode)
+    (goto-char (point-min))
+    (forward-line 2)
+    (end-of-line)
+    (let ((before (current-column))
+          (this-command 'indent-for-tab-command))
+      (indent-according-to-mode)
+      (should (= (current-column) before)))))
+
+(ert-deftest M2-simple-doc-test-the-commonest-step-ties-towards-the-top ()
+  "Where two steps are equally common, the one used first wins.
+A docstring is read downwards, so the step its opening sections are
+written in is the one to follow."
+  ;; The arguments arrive as the parser pushes them, bottom line first.
+  (should (= (M2-simple-doc--mode-of '(4 2 4 2) 99) 2))
+  (should (= (M2-simple-doc--mode-of '(4 2) 99) 2))
+  ;; A clear majority wins whichever end it is at.
+  (should (= (M2-simple-doc--mode-of '(4 4 2) 99) 4))
+  (should (= (M2-simple-doc--mode-of '() 99) 99)))
+
+(ert-deftest M2-simple-doc-test-tab-still-inserts-one-where-nothing-is-known ()
+  "In a body whose indentation is content, an explicit tab is still a tab.
+`Pre' is taken verbatim, so the engine has nothing to say about where its
+lines go; TAB there does what it does in code, and inserts."
+  (should (equal (M2-simple-doc-tests--tab "doc ///
+  Description
+    Pre
+      raw
+///
+" 3 9)
+                 (concat "doc ///\n  Description\n    Pre\n      raw"
+                         (make-string M2-indent-level ?\s)
+                         "\n///\n"))))
+
+(ert-deftest M2-simple-doc-test-tab-places-a-keyword-by-its-table ()
+  "TAB puts a keyword where the table that admits it says, not where it sits.
+`Text' is legal only inside a `Description', so TAB moves it into the one
+above --- which is what lets the engine correct a docstring rather than
+ratify it."
+  (should (equal (M2-simple-doc-tests--tab "\
+doc ///
+  Description
+Text
+      prose
+///
+" 2)
+                 "\
+doc ///
+  Description
+    Text
+      prose
+///
+")))
+
+(ert-deftest M2-simple-doc-test-bulk-indent-does-not-restructure ()
+  "`indent-region' must not turn body text into a section.
+The `Example' below sits inside the body of the `Text' above it, so
+SimpleDoc reads it as a line of that paragraph, however much it looks
+like a section.  Moving it up beside the `Text' would add an example to
+the documentation that its author never wrote, so reindenting a whole
+file leaves it alone; TAB on the line still promotes it."
+  (let ((text "\
+doc ///
+  Description
+    Text
+      prose
+      Example
+      2+2
+///
+"))
+    (should (equal (M2-simple-doc-tests--indent text) text))))
+
+(ert-deftest M2-simple-doc-test-ambiguous-keywords-take-the-inner-table ()
+  "`Description' is legal in both a `Node' and a `Synopsis'.
+The innermost section that admits it wins, which is the dispatch
+SimpleDoc itself performs."
+  ;; Inside a Synopsis, it belongs to the Synopsis.
+  (should (equal (M2-simple-doc-tests--indent "\
+doc ///
+Node
+    Key
+        foo
+    Synopsis
+        Usage
+            foo n
+        Description
+            Text
+                prose
+///
+")
+                 "\
+doc ///
+Node
+    Key
+        foo
+    Synopsis
+        Usage
+            foo n
+        Description
+            Text
+                prose
+///
+"))
+  ;; With no Synopsis in the way, it belongs to the Node.
+  (should (equal (M2-simple-doc-tests--indent "\
+doc ///
+Node
+    Key
+        foo
+    Description
+        Text
+            prose
+///
+")
+                 "\
+doc ///
+Node
+    Key
+        foo
+    Description
+        Text
+            prose
+///
+")))
+
+(M2-simple-doc-tests--deftest M2-simple-doc-test-nodes-do-not-nest
+  ;; `Node' is in its own body table, so a node can be made to nest inside
+  ;; another; nothing consumes a nested one, and reading the second `Node'
+  ;; below as a subsection of the first would swallow it and every node
+  ;; after it.  Each is a section of the docstring itself.
+  "doc ///
+Node
+  Key
+    foo
+  Description
+    Text
+      prose
+Node
+  Key
+    bar
+///
+")
+
+(ert-deftest M2-simple-doc-test-word-that-is-not-a-keyword-here ()
+  "A word is a keyword only where the table in force admits it.
+`Text' alone on a line of a `Key' is a Macaulay2 expression naming the
+symbol `Text', not the opening of a section, so it stays where it is."
+  (should (equal (M2-simple-doc-tests--indent "\
+doc ///
+  Key
+    Text
+    (foo, ZZ)
+///
+")
+                 "\
+doc ///
+  Key
+    Text
+    (foo, ZZ)
+///
+")))
+
+;;; Measuring a line, as splitByIndent measures it.
+
+(ert-deftest M2-simple-doc-test-indentation-is-measured-in-columns ()
+  "A tab advances to the next multiple of eight, whatever `tab-width' is.
+SimpleDoc says so, and a good third of Macaulay2's own docstrings are
+indented with tabs, so a mode that counted characters would misread them."
+  (dolist (case '(("\tx" . 8) (" \tx" . 8) ("       \tx" . 8)
+                  ("        \tx" . 16) ("  \r x" . 1) ("    x" . 4)))
+    (with-temp-buffer
+      (insert (car case))
+      (let ((tab-width 4))              ; deliberately not eight
+        (should (equal (cons (car case) (M2-simple-doc--indentation))
+                       case)))))
+  ;; A line of nothing but whitespace is blank, which is an infinite
+  ;; indentation rather than column zero: that is what lets a blank line
+  ;; continue a section instead of ending it.
+  (dolist (blank '("" "   " "\t"))
+    (with-temp-buffer
+      (insert blank)
+      (should-not (M2-simple-doc--indentation)))))
+
+(M2-simple-doc-tests--deftest M2-simple-doc-test-tabs-are-left-alone
+  "doc ///
+\tKey
+\t\tfoo
+\tHeadline
+\t\ta headline
+///
+")
+
+(M2-simple-doc-tests--deftest M2-simple-doc-test-comment-does-not-break-a-block
+  ;; A line matching "^[[:space:]]*--" is deleted before any indentation is
+  ;; measured, so however far left it sits it cannot end a section.
+  "doc ///
+  Description
+    Text
+      prose
+-- a comment at column zero
+      more prose
+///
+")
+
+(M2-simple-doc-tests--deftest M2-simple-doc-test-blank-line-does-not-break-a-block
+  "doc ///
+  Description
+    Text
+      one paragraph
+
+      and another
+///
+")
+
+;;; The base and the step are inferred, not imposed.
+
+(M2-simple-doc-tests--deftest M2-simple-doc-test-house-style-two
+  "doc ///
+  Key
+    foo
+  Description
+    Text
+      prose
+///
+")
+
+(M2-simple-doc-tests--deftest M2-simple-doc-test-house-style-four
+  "doc ///
+    Key
+        foo
+    Description
+        Text
+            prose
+///
+")
+
+(M2-simple-doc-tests--deftest M2-simple-doc-test-house-style-one
+  "doc ///
+ Key
+  foo
+ Description
+  Text
+   prose
+///
+")
+
+(M2-simple-doc-tests--deftest M2-simple-doc-test-node-at-column-zero
+  "doc ///
+Node
+    Key
+        foo
+    Description
+        Text
+            prose
+///
+")
+
+;;; Bodies whose indentation is content.
+
+(M2-simple-doc-tests--deftest M2-simple-doc-test-verbatim-bodies-untouched
+  ;; Pre subtracts the least indentation in the section, CannedExample and
+  ;; Citation that of their first line, and a line shallower than the
+  ;; reference is flushed left rather than kept where it was.  Reindenting
+  ;; any of them would change what is rendered.
+  "doc ///
+  Description
+    Pre
+         deliberately
+           ragged
+      text
+    CannedExample
+        i1 : 2+2
+        o1 = 4
+///
+")
+
+(M2-simple-doc-tests--deftest M2-simple-doc-test-item-descriptions-untouched
+  "doc ///
+  Inputs
+    n:ZZ
+      the number of things
+    R:Ring
+        indented further, and left that way
+  Outputs
+    :List
+      the things
+///
+")
+
+(M2-simple-doc-tests--deftest M2-simple-doc-test-menu-nesting-untouched
+  "doc ///
+  Subnodes
+    :A heading
+    foo
+      bar
+        baz
+///
+")
+
+;;; Example and Code.
+
+(M2-simple-doc-tests--deftest M2-simple-doc-test-examples-stay-separate
+  ;; Each line at the base begins an example of its own.  Were SMIE allowed
+  ;; to pull the second one in, the two would render as one.
+  "doc ///
+  Description
+    Example
+      R = QQ[x];
+      I = ideal x
+///
+")
+
+(M2-simple-doc-tests--deftest M2-simple-doc-test-example-continues-under-smie
+  "doc ///
+  Description
+    Example
+      f = i -> (
+          a := i^2;
+          a+1)
+///
+")
+
+(ert-deftest M2-simple-doc-test-example-is-indented-relative-to-its-section ()
+  "SMIE indents an example's body from the section's base, not from column 0.
+The body of an `Example' is a block of Macaulay2 that the section around
+it has already pushed to the right."
+  (should (equal (M2-simple-doc-tests--indent "\
+doc ///
+  Description
+    Example
+      f = i -> (
+      a := i^2;
+          a+1)
+///
+")
+                 ;; The line already at the base begins a new example and is
+                 ;; left there; the deeper one is placed by SMIE, relative
+                 ;; to the base rather than to the left margin.
+                 "\
+doc ///
+  Description
+    Example
+      f = i -> (
+      a := i^2;
+          a+1)
+///
+")))
+
+(M2-simple-doc-tests--deftest M2-simple-doc-test-example-base-is-the-authors
+  ;; The first line of an `Example' fixes the base indentation of the whole
+  ;; section, and with it the grouping of every line after it.  Pulling it
+  ;; back to the usual step, as the body of a prose section would be, would
+  ;; leave the lines after it deeper than the base and run two examples
+  ;; into one.  Here the body sits far in from its keyword and stays there.
+  "doc ///
+  Description
+    Example
+          K = f 4
+          J = g K
+///
+")
+
+(M2-simple-doc-tests--deftest M2-simple-doc-test-example-floor-only-falls
+  ;; An Example body is divided the way a docstring is: a line no deeper
+  ;; than the running floor begins a new example and lowers the floor.  So
+  ;; the three lines below are three examples even though the first is the
+  ;; deepest, and none of them may be moved.  Reading the rule as "at the
+  ;; base" rather than "no deeper than the floor" ran them all into one.
+  "doc ///
+  Description
+    Example
+       Q = QQ[x,y,z];
+      f Q
+      g Q
+///
+")
+
+(M2-simple-doc-tests--deftest M2-simple-doc-test-code-is-indented-freely
+  ;; A Code section is one parenthesized expression with no grouping to
+  ;; preserve, so SMIE has a free hand there.
+  "doc ///
+  Description
+    Code
+      PARA {
+          \"hi\"}
+///
+")
+
+;;; The clamps.
+
+(ert-deftest M2-simple-doc-test-a-line-is-not-moved-past-its-own-body ()
+  "A keyword is left alone rather than moved out over the lines beneath it.
+An indentation function moves one line while its neighbours stay put, so
+a move that would strand this section's body outside it is refused.  Here
+the second `Text' belongs beside the first, at column 4, but its own
+prose sits at column 3: moving it there would leave the prose behind, no
+longer part of the section it describes."
+  (should (equal (M2-simple-doc-tests--indent "\
+doc ///
+  Description
+    Text
+      prose
+  Text
+   more prose
+///
+")
+                 "\
+doc ///
+  Description
+    Text
+      prose
+  Text
+   more prose
+///
+")))
+
+(M2-simple-doc-tests--deftest M2-simple-doc-test-a-line-is-not-moved-into-another
+  ;; The `SeeAlso' below is a section of the `Node': at column 1 nothing
+  ;; stands between them.  Its siblings sit at column 4, but it may not
+  ;; join them, because the stray line at column 2 opened a block of its
+  ;; own that reaches column 4 --- moving it there would make it a line of
+  ;; that block rather than a section at all.  A line indented past its
+  ;; siblings is not beside them.
+  "doc ///
+Node
+    Key
+      foo
+    Description
+      Text
+        prose
+  a stray line
+ SeeAlso
+      bar
+///
+")
+
+;;; Cycling through the possibilities with TAB.
+
+(defun M2-simple-doc-tests--tab-cycle (text line presses)
+  "Press TAB PRESSES times on LINE of TEXT and return the columns reached."
+  (with-temp-buffer
+    (insert text)
+    (M2-mode)
+    (goto-char (point-min))
+    (forward-line line)
+    (let ((last-command nil) (columns nil))
+      (dotimes (_ presses)
+        (let ((this-command 'indent-for-tab-command))
+          (indent-according-to-mode)
+          (push (current-indentation) columns)
+          (setq last-command this-command)))
+      (nreverse columns))))
+
+(ert-deftest M2-simple-doc-test-tab-cycles-through-the-levels ()
+  "TAB pressed again steps out to the next level that would make sense.
+Under a key, the next line may be another key or a new section of the
+node, and only the writer knows which; the first TAB offers the likelier,
+and the second the other.  At the end the cycle comes round again, as it
+does in `python-mode'."
+  (should (equal (M2-simple-doc-tests--tab-cycle "doc ///
+  Key
+    foo
+
+///
+" 3 5)
+                 ;; The body of Key, then beside Key itself, then round.
+                 '(4 2 4 2 4))))
+
+(ert-deftest M2-simple-doc-test-tab-cycle-offers-each-enclosing-level ()
+  "Every level a line could belong to is offered, innermost first."
+  (should (equal (M2-simple-doc-tests--tab-cycle "doc ///
+  Inputs
+    n:ZZ
+      what n is
+
+///
+" 4 4)
+                 ;; Another line of the description, another item, another
+                 ;; section of the node, and round again.
+                 '(6 4 2 6))))
+
+(ert-deftest M2-simple-doc-test-tab-cycle-leaves-a-line-with-text-alone ()
+  "Cycling is for a line still being written, not for reflowing prose."
+  (let ((text "doc ///
+  Description
+    Text
+      prose
+///
+"))
+    (should (equal (M2-simple-doc-tests--tab-cycle text 3 3) '(6 6 6)))))
+
+;;; Correcting a line by hand.
+
+(ert-deftest M2-simple-doc-test-tab-lines-up-a-stray-example-line ()
+  "TAB on a line SMIE reads as a statement of its own puts it at the floor.
+A line one column too deep goes on being part of the example above it,
+which is rarely what was meant, so TAB lines it up.  `indent-region'
+leaves it alone: moving it makes an example of it, which changes what
+`installPackage' runs, and that is not a thing to do to a whole file."
+  (let ((text "doc ///
+  Description
+    Example
+      x
+       y
+///
+"))
+    (should (equal (M2-simple-doc-tests--tab text 4) "\
+doc ///
+  Description
+    Example
+      x
+      y
+///
+"))
+    (should (equal (M2-simple-doc-tests--indent text) text))))
+
+(ert-deftest M2-simple-doc-test-tab-brings-in-a-line-typed-at-the-margin ()
+  "TAB on a line that has fallen short of its section brings it in.
+A line is typed from the left margin, and until it is indented it sits
+below everything around it.  Doing nothing there --- on the grounds that
+a shallower line begins something new --- leaves TAB dead on the one line
+that most needs it.  `indent-region' still does nothing: a line shallower
+than its neighbours may have been meant to close the section."
+  (dolist (case '(("doc ///\n  Description\n    Example\n      x\ny\n///\n" 4 "      y")
+                  ("doc ///\n  Description\n    Text\n      prose\ny\n///\n" 4 "      y")
+                  ("doc ///\n  Key\n    foo\nbar\n///\n" 3 "    bar")))
+    (let ((text (nth 0 case)) (line (nth 1 case)) (want (nth 2 case)))
+      (with-temp-buffer
+        (insert (M2-simple-doc-tests--tab text line))
+        (goto-char (point-min))
+        (forward-line line)
+        (should (equal (buffer-substring-no-properties
+                        (line-beginning-position) (line-end-position))
+                       want)))
+      ;; ...but a whole-file reindentation leaves it alone.
+      (should (equal (M2-simple-doc-tests--indent text) text)))))
+
+(M2-simple-doc-tests--deftest M2-simple-doc-test-item-description-keeps-its-depth
+  ;; The description of an item is deeper than its head, and that is what
+  ;; makes it the description.  TAB must not pull it up to the head level.
+  "doc ///
+  Inputs
+    n:ZZ
+      what n is
+///
+")
+
+(M2-simple-doc-tests--deftest M2-simple-doc-test-example-continuation-stays-deep
+  ;; A line SMIE reads as continuing an expression --- here an argument of
+  ;; a call whose bracket is still open --- belongs deeper than the floor,
+  ;; and goes on being part of the same example.  The column is the one
+  ;; M2-mode gives such a line anywhere else: the bracket's own, plus
+  ;; `M2-indent-level'.
+  "doc ///
+  Description
+    Example
+      f(a,
+           b)
+///
+")
+
+;;; Writing one from nothing.
+
+(defun M2-simple-doc-tests--type (keys)
+  "Type KEYS into an empty `M2-mode' buffer and return what comes out.
+KEYS is a list of strings to insert and of the symbols `ret' and `tab',
+which run the commands those keys are bound to.  Each is run as the
+command loop would run it, setting `this-command' and `last-command', so
+that the rules keyed on them --- the tab that indents rather than
+inserts, the second tab that cycles --- are exercised as they are in use."
+  (with-temp-buffer
+    (M2-mode)
+    (electric-indent-local-mode 1)
+    (let ((last-command nil))
+      (dolist (key keys)
+        (let ((this-command (cond ((eq key 'ret) 'newline)
+                                  ((eq key 'tab) 'indent-for-tab-command)
+                                  (t 'self-insert-command))))
+          (cond ((eq key 'ret) (call-interactively #'newline))
+                ((eq key 'tab) (call-interactively #'indent-for-tab-command))
+                (t (insert key)))
+          (setq last-command this-command))))
+    (buffer-string)))
+
+(ert-deftest M2-simple-doc-test-a-docstring-can-be-typed ()
+  "A whole node comes out indented, typed as one would type it.
+The point is where typing leaves it --- at the end of the line --- and
+RET is what opens each new line.  Every bug found in this engine by
+actually using it lived on that path and not on `indent-region', which is
+what the rest of these tests and the corpus check exercise."
+  (should (equal (M2-simple-doc-tests--type
+                  '("doc ///" ret
+                    "Key" ret
+                    "(foo, ZZ)" ret
+                    "Headline" tab ret
+                    "what foo does" ret
+                    "Description" tab ret
+                    "Text" ret
+                    "some prose" ret
+                    "Example" tab ret
+                    "2+2" ret
+                    "3+3" ret
+                    "///"))
+                 "doc ///
+  Key
+    (foo, ZZ)
+  Headline
+    what foo does
+  Description
+    Text
+      some prose
+    Example
+      2+2
+      3+3
+      ///")))
+
+(ert-deftest M2-simple-doc-test-typing-a-multi-line-example ()
+  "An example spanning several lines indents itself as it is typed.
+While a bracket is open the doc string is unbalanced, so
+`M2-syntax-propertize' demotes it to punctuation to stop prose displacing
+the code after it.  SMIE cannot indent by a bracket it cannot see as one,
+and read that way it does not answer at all, which left every such line
+at the left margin.  Inside a body that really is Macaulay2 the syntax
+table alone is used, so the bracket counts again."
+  (should (equal (M2-simple-doc-tests--type
+                  '("doc ///" ret "Description" ret "Example" tab ret
+                    "f = x -> (" ret "a := x^2;" ret "a+1)" ret "f 3"))
+                 "doc ///
+  Description
+    Example
+      f = x -> (
+          a := x^2;
+          a+1)
+      f 3"))
+  ;; `f 3' is a statement of its own, so it goes back to the floor and is
+  ;; an example of its own, as it would be had it been written that way.
+  (should (equal (M2-simple-doc-tests--type
+                  '("doc ///" ret "Description" ret "Example" tab ret
+                    "f = x -> (" ret))
+                 "doc ///\n  Description\n    Example\n      f = x -> (\n          ")))
+
+(ert-deftest M2-simple-doc-test-typing-inside-an-unfinished-string ()
+  "Where SMIE will not answer, a line just opened still lands somewhere.
+Inside a string it declines, and the floor --- where the example began
+--- is the one column that cannot be wrong."
+  (should (equal (M2-simple-doc-tests--type
+                  '("doc ///" ret "Description" ret "Example" tab ret
+                    "s = \"abc" ret))
+                 "doc ///\n  Description\n    Example\n      s = \"abc\n      ")))
+
+(ert-deftest M2-simple-doc-test-typing-reaches-every-level-with-tab ()
+  "A line typed at the margin is brought in by TAB, at any depth."
+  ;; RET after `Text' opens its body; the prose is typed there directly.
+  (should (equal (M2-simple-doc-tests--type
+                  '("doc ///" ret "Description" ret "Text" ret "prose"))
+                 "doc ///\n  Description\n    Text\n      prose"))
+  ;; And a keyword typed where RET left it is moved out to its own level.
+  (should (equal (M2-simple-doc-tests--type
+                  '("doc ///" ret "Key" ret "foo" ret "Headline" tab))
+                 "doc ///\n  Key\n    foo\n  Headline")))
+
+;;; Strings still being typed.
+
+(ert-deftest M2-simple-doc-test-unterminated-string-makes-progress ()
+  "A docstring with no closing /// yet must still indent, and must not hang."
+  (dolist (text '("doc ///\n" "doc ///\nKey\n" "doc ///\n  Description\n    Text\n"))
+    (with-temp-buffer
+      (insert text)
+      (M2-mode)
+      (let ((inhibit-message t))
+        (with-timeout (10 (ert-fail "indentation did not finish"))
+          (indent-region (point-min) (point-max))))))
+  ;; At the very end of the buffer there is no character to carry the
+  ;; property that marks the string, so the position before it is used.
+  (with-temp-buffer
+    (insert "doc ///\nKey\n")
+    (M2-mode)
+    (goto-char (point-max))
+    (should (M2-inside-simple-doc-p (point)))))
+
+(ert-deftest M2-simple-doc-test-terminator-line-is-not-simple-doc ()
+  "The line holding the closing /// belongs to the Macaulay2 around it."
+  (should (equal (M2-simple-doc-tests--indent "\
+doc ///
+  Key
+    foo
+///
+")
+                 "\
+doc ///
+  Key
+    foo
+///
+")))
+
+;;; Opening a line.
+
+(ert-deftest M2-simple-doc-test-new-line-begins-the-body-of-a-section ()
+  "RET after a keyword lands where that section's body belongs."
+  (with-temp-buffer
+    (insert "doc ///\n  Description\n\n///\n")
+    (M2-mode)
+    (goto-char (point-min))
+    (forward-line 2)
+    (indent-according-to-mode)
+    ;; A `Description' holds sections, so the next line is a subsection.
+    (should (= (current-indentation) (+ 2 M2-simple-doc-indent-level)))))
+
+(ert-deftest M2-simple-doc-test-new-line-continues-a-paragraph ()
+  "RET inside a paragraph carries on at the same column."
+  (with-temp-buffer
+    (insert "doc ///\n  Description\n    Text\n      prose\n\n///\n")
+    (M2-mode)
+    (goto-char (point-min))
+    (forward-line 4)
+    (indent-according-to-mode)
+    (should (= (current-indentation) 6))))
+
+(provide 'M2-simple-doc-tests)
+
+;;; M2-simple-doc-tests.el ends here

--- a/test/M2-smie-tests.el
+++ b/test/M2-smie-tests.el
@@ -1,0 +1,605 @@
+;;; M2-smie-tests.el --- Tests for M2-mode indentation  -*- lexical-binding: t -*-
+
+;; Copyright (C) 2026 Daniel R. Grayson and Doug Torrance
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Tests for the SMIE-based indentation in M2.el.  Load this file and run
+;; `ert', or run them in batch the way .github/workflows/test.yml does.
+
+;;; Code:
+
+(require 'ert)
+(require 'M2)
+
+(defun M2-smie-tests--reindent (text)
+  "Strip all indentation from TEXT, re-indent it in `M2-mode', and return it."
+  (with-temp-buffer
+    (insert text)
+    (M2-mode)
+    (goto-char (point-min))
+    (while (not (eobp))
+      (delete-horizontal-space)
+      (forward-line 1))
+    (indent-region (point-min) (point-max))
+    (buffer-string)))
+
+(defmacro M2-smie-tests--deftest (name text)
+  "Define an indentation test NAME asserting that TEXT re-indents to itself."
+  (declare (indent 1))
+  `(ert-deftest ,name ()
+     (should (equal (M2-smie-tests--reindent ,text) ,text))))
+
+;;; Keyword expressions, one per production in the Macaulay2 language grammar.
+
+(M2-smie-tests--deftest M2-smie-test-if-then-else "\
+f = x -> (
+    if x
+    then y
+    else z)
+")
+
+(M2-smie-tests--deftest M2-smie-test-if-then-else-blocks "\
+if x then (
+    a;
+    b) else (
+    c;
+    d)
+")
+
+(M2-smie-tests--deftest M2-smie-test-try-then-else "\
+f = (
+    try g
+    then h
+    else k)
+")
+
+(M2-smie-tests--deftest M2-smie-test-try-except-do "\
+f = (
+    try g
+    except e do
+        h)
+")
+
+(M2-smie-tests--deftest M2-smie-test-while-do "\
+while x do (
+    a;
+    b)
+")
+
+(M2-smie-tests--deftest M2-smie-test-while-list-do "\
+f = (
+    while x
+    list y
+    do z)
+")
+
+(M2-smie-tests--deftest M2-smie-test-for-in-do "\
+for i in L do (
+    a;
+    b)
+")
+
+(M2-smie-tests--deftest M2-smie-test-for-from-to-when-list "\
+f = (
+    for i
+    from 1
+    to 10
+    when odd i
+    list i^2)
+")
+
+(M2-smie-tests--deftest M2-smie-test-new-of-from "\
+f = (
+    new HashTable
+    of Thing
+    from {})
+")
+
+;;; Brackets, separators, and operators.
+
+(M2-smie-tests--deftest M2-smie-test-nested-brackets "\
+L = {
+    1,
+    2,
+    {
+        3,
+        4}
+}
+")
+
+(M2-smie-tests--deftest M2-smie-test-method-options "\
+foo = method(
+    Options => {
+        A => 1,
+        B => 2})
+")
+
+(M2-smie-tests--deftest M2-smie-test-hanging-arrow "\
+f = (a,b) -> (
+    a+b)
+")
+
+(M2-smie-tests--deftest M2-smie-test-documentation-block "\
+beginDocumentation()
+document {
+    Key => foo,
+    Headline => \"bar\",
+    PARA {
+        \"text\"
+    }
+}
+")
+
+(M2-smie-tests--deftest M2-smie-test-top-level-statements "\
+a = 1;
+b = 2;
+c = 3
+")
+
+(M2-smie-tests--deftest M2-smie-test-binary-continuation "\
+x = a +
+    b +
+    c
+")
+
+(M2-smie-tests--deftest M2-smie-test-angle-bar-brackets "\
+x = <|
+    a,
+    b|>
+")
+
+;;; Regressions.
+
+(M2-smie-tests--deftest M2-smie-test-trailing-comment "\
+a = 1
+b = 2   -- a trailing comment must not drag the next statement rightwards
+c = 3
+")
+
+(M2-smie-tests--deftest M2-smie-test-assignment-then-statement "\
+x = 20
+y := 3
+z <- identity
+w = 4
+")
+
+(ert-deftest M2-smie-test-block-comment ()
+  "Code after a -* ... *- comment must still be indented to the block."
+  (with-temp-buffer
+    (insert "f = (\n-* a block\n   comment *-\n1)\n")
+    (M2-mode)
+    (indent-region (point-min) (point-max))
+    (goto-char (point-min))
+    (forward-line 1)
+    (should (= (current-indentation) M2-indent-level))
+    (forward-line 2)                    ; past the comment's second line
+    (should (= (current-indentation) M2-indent-level))))
+
+(M2-smie-tests--deftest M2-smie-test-string-with-brackets "\
+f = (
+    print \"( unbalanced [ brackets { in a string\",
+    1)
+")
+
+(ert-deftest M2-smie-test-no-tabs ()
+  "Indentation must never insert a literal tab."
+  (should-not (string-match-p "\t" (M2-smie-tests--reindent "\
+f = (
+    g = {
+        1,
+        2};
+    h)
+"))))
+
+(ert-deftest M2-smie-test-idempotent ()
+  "Indenting an already-indented buffer must change nothing."
+  (let ((text "\
+f = x -> (
+    if x
+    then (
+        a;
+        b)
+    else c)
+"))
+    (should (equal (M2-smie-tests--reindent
+                    (M2-smie-tests--reindent text))
+                   text))))
+
+;;; The lexer.
+
+(defconst M2-smie-tests--operators
+  (append (apply #'append (mapcar #'cdr M2-operators-binary))
+          M2-operators-postfix)
+  "Every operator the lexer has to recognize.
+Derived from the generated table rather than listed here, so that an
+operator added to Macaulay2 is covered as soon as it is regenerated.
+The sum-of-twists operator (*) is absent from that table on purpose: it
+is already balanced parentheses, so both directions of the lexer decline
+it and let SMIE step over it as a sexp.")
+
+(ert-deftest M2-smie-test-lexer-round-trip ()
+  "Forward and backward tokenization must agree on every operator.
+SMIE requires the two token functions to be exact inverses; when they are
+not, it scans past the tokens it is looking for."
+  (let (failures)
+    (dolist (op M2-smie-tests--operators)
+      (with-temp-buffer
+        (insert "a " op " b")
+        (M2-mode)
+        (goto-char (point-min))
+        (M2-smie-forward-token)
+        (let ((forward (M2-smie-forward-token)))
+          (goto-char (point-max))
+          (M2-smie-backward-token)
+          (let ((backward (M2-smie-backward-token)))
+            (unless (and (equal forward op) (equal backward op))
+              (push (format "%s: forward %S, backward %S" op forward backward)
+                    failures))))))
+    (should-not (nreverse failures))))
+
+(ert-deftest M2-smie-test-lexer-makes-progress ()
+  "Tokenizing must always move point, in both directions.
+A token function that returns without moving makes SMIE loop."
+  (let ((text "x = \"a string\" + ///a raw string/// - f(1,2) -- comment\ny = 3\n"))
+    (with-temp-buffer
+      (insert text)
+      (M2-mode)
+      (goto-char (point-min))
+      (while (< (point) (point-max))
+        (let ((start (point)))
+          (M2-smie-forward-token)
+          (when (= (point) start)
+            ;; An empty token that does not move is SMIE's signal to step
+            ;; over the object at point itself; emulate that.
+            (goto-char (or (ignore-errors
+                             (let ((forward-sexp-function nil))
+                               (scan-sexps (point) 1)))
+                           (point-max))))
+          (should (> (point) start))))
+      (goto-char (point-max))
+      (while (> (point) (point-min))
+        (let ((start (point)))
+          (M2-smie-backward-token)
+          (when (= (point) start)
+            (goto-char (or (ignore-errors
+                             (let ((forward-sexp-function nil))
+                               (scan-sexps (point) -1)))
+                           (point-min))))
+          (should (< (point) start)))))))
+
+(ert-deftest M2-smie-test-unterminated-literals ()
+  "Half-typed comments and strings must not make indentation hang."
+  (dolist (text '("f = (\n-* an unterminated block comment\n"
+                  "f = (\n\"an unterminated string\n"
+                  "f = (\n///an unterminated raw string\n"
+                  "f = (\n--\n"))
+    (with-temp-buffer
+      (insert text)
+      (M2-mode)
+      ;; SMIE reports and absorbs the scan-error an unterminated string
+      ;; provokes, but only when `debug-on-error' is off, which it is not
+      ;; under ERT.  What is being checked here is that we come back at all.
+      (let ((debug-on-error nil))
+        (with-timeout (10 (ert-fail (format "timed out on %S" text)))
+          (ignore-errors (indent-region (point-min) (point-max))))))))
+
+(ert-deftest M2-smie-test-triple-slash-is-not-a-string ()
+  "///.../// must not be given string syntax.
+It is used for doc and TEST strings whose contents are Macaulay2 code, and
+we want that code treated as code."
+  (with-temp-buffer
+    (insert "TEST ///\n  R = QQ[x,y]\n  assert(dim R == 2)\n///\n")
+    (M2-mode)
+    (syntax-propertize (point-max))
+    (goto-char (point-min))
+    (while (not (eobp))
+      (should-not (nth 3 (syntax-ppss (point))))
+      (forward-char 1))))
+
+(defconst M2-smie-tests--doc "\
+doc ///
+  Key
+    (foo, ZZ)
+  Description
+    Text
+      Some prose that runs
+      onto a second line.
+    Example
+      R = QQ[x]
+///
+x = 1
+")
+
+(ert-deftest M2-smie-test-documentation-is-left-alone ()
+  "Indenting must not disturb a doc string.
+Those are written in SimpleDoc, whose indentation is significant and which
+this mode does not understand."
+  (with-temp-buffer
+    (insert M2-smie-tests--doc)
+    (M2-mode)
+    (indent-region (point-min) (point-max))
+    (should (equal (buffer-string) M2-smie-tests--doc))))
+
+(ert-deftest M2-smie-test-documentation-continues-previous-line ()
+  "A new line inside a doc string picks up the previous line's indentation."
+  (with-temp-buffer
+    (insert M2-smie-tests--doc)
+    (M2-mode)
+    (goto-char (point-min))
+    (forward-line 6)                    ; "      onto a second line."
+    (end-of-line)
+    (newline)
+    (indent-according-to-mode)
+    (should (= (current-indentation) 6))
+    ;; ...and the line it was split from is untouched.
+    (forward-line -1)
+    (should (= (current-indentation) 6))))
+
+(ert-deftest M2-smie-test-test-blocks-indent-as-code ()
+  "TEST ///...///  holds Macaulay2 code, so it is indented as code."
+  (should (equal (M2-smie-tests--reindent "\
+TEST ///
+R = QQ[x]
+f = i -> (
+    a := i^2;
+    a+1)
+///
+")
+                 "\
+TEST ///
+R = QQ[x]
+f = i -> (
+    a := i^2;
+    a+1)
+///
+")))
+
+(ert-deftest M2-smie-test-stray-triple-slash-is-ignored ()
+  "A /// inside a comment or a string must not be taken for a delimiter.
+Counting one would flip the open/close parity and silently stop
+indentation for the rest of the buffer."
+  (dolist (prefix '("-- see /// for raw strings\n" "s = \"///\"\n"))
+    (should (equal (M2-smie-tests--reindent (concat prefix "f = (\na;\nb)\n"))
+                   (concat prefix "f = (\n    a;\n    b)\n")))))
+
+(ert-deftest M2-smie-test-bracket-with-trailing-comment ()
+  "A bracket followed by a comment is still hanging.
+Otherwise its contents line up with the comment, and the first element
+gets a different column from the rest."
+  (should (equal (M2-smie-tests--reindent "\
+someLongName = { -- why
+    a,
+    b,
+    c}
+")
+                 "\
+someLongName = { -- why
+    a,
+    b,
+    c}
+")))
+
+(ert-deftest M2-smie-test-separator-cache-respects-narrowing ()
+  "The newline cache must not carry a narrowed answer back out.
+`M2-smie--matching-block-data' runs the lexer inside `narrow-to-region',
+where a newline near the edge looks like a statement separator because
+the token before it is out of reach."
+  (with-temp-buffer
+    (insert "x = aaa +\nbbb\n")
+    (M2-mode)
+    (goto-char (point-min))
+    (end-of-line)                       ; the newline after "+"
+    (let ((pos (point)))
+      (should-not (M2-smie--newline-separator-p))
+      (should (save-restriction (narrow-to-region pos (point-max))
+                                (M2-smie--newline-separator-p)))
+      ;; Unrestricted again, and the buffer has not changed.
+      (should-not (M2-smie--newline-separator-p)))))
+
+(ert-deftest M2-smie-test-blank-line-in-documentation-kept ()
+  "A whitespace-only line in a doc string keeps its whitespace.
+It may well be significant to SimpleDoc."
+  (let ((text "doc ///\n  Key\n    foo\n  \n  Headline\n///\n"))
+    (with-temp-buffer
+      (insert text)
+      (M2-mode)
+      (indent-region (point-min) (point-max))
+      (should (equal (buffer-string) text)))))
+
+(ert-deftest M2-smie-test-comment-syntax-is-respected ()
+  "The lexer must take -- to start a comment only where the syntax does.
+`M2-syntax-propertize-function' clears the comment flags inside comint
+output blocks, where -- is part of Macaulay2's output."
+  (with-temp-buffer
+    (M2-comint-mode)
+    (insert "i1 : 3-4\n")
+    (let ((start (point)))
+      (insert "o1 = -- output, not a comment\n")
+      (put-text-property start (point) 'field 'output))
+    (syntax-propertize (point-max))
+    (goto-char (point-min))
+    (search-forward "--")
+    (backward-char 2)
+    (should-not (M2-smie--comment-start-p (point)))
+    ;; Lexed as the subtraction operator, so the rest of the line survives.
+    (should (equal (M2-smie-forward-token) "-")))
+  (with-temp-buffer
+    (M2-mode)
+    (insert "x = 1 -- a real comment\ny = 2\n")
+    (syntax-propertize (point-max))
+    (goto-char (point-min))
+    (search-forward "--")
+    (backward-char 2)
+    (should (M2-smie--comment-start-p (point)))
+    ;; Skipped, leaving the newline to end the statement.
+    (should (equal (M2-smie-forward-token) ";"))))
+
+(defun M2-smie-tests--indentations (text)
+  "Return the indentation of each line of TEXT after re-indenting it."
+  (with-temp-buffer
+    (insert text)
+    (M2-mode)
+    (goto-char (point-min))
+    (while (not (eobp))
+      (delete-horizontal-space)
+      (forward-line 1))
+    (indent-region (point-min) (point-max))
+    (let (columns)
+      (goto-char (point-min))
+      (while (not (eobp))
+        (push (current-indentation) columns)
+        (forward-line 1))
+      (nreverse columns))))
+
+(defun M2-smie-tests--face-at (text string)
+  "Return the face on the first occurrence of STRING in TEXT."
+  (with-temp-buffer
+    (insert text)
+    (M2-mode)
+    (font-lock-ensure)
+    (goto-char (point-min))
+    (search-forward string)
+    (get-text-property (- (point) (length string)) 'face)))
+
+(ert-deftest M2-smie-test-documentation-string-is-not-a-string ()
+  "A doc string stays ordinary text, so Macaulay2 inside it is marked up.
+In particular a \"...\" written in one is a real string; Emacs has no
+nested strings, so this only works while the block itself is not one."
+  (let ((text "doc ///\nideal \"foo\" here\n///\n"))
+    (should-not (nth 3 (with-temp-buffer
+                         (insert text) (M2-mode)
+                         (syntax-propertize (point-max))
+                         (syntax-ppss (+ (point-min) 12)))))
+    (should (eq (M2-smie-tests--face-at text "\"foo\"") 'font-lock-string-face))
+    (should (eq (M2-smie-tests--face-at text "ideal")
+                'font-lock-function-name-face))))
+
+(ert-deftest M2-smie-test-documentation-prose-cannot-leak ()
+  "An unbalanced delimiter in doc prose must not displace what follows."
+  (dolist (prose '("a lone ( paren" "a lone \" quote" "a lone ) paren"))
+    (should (equal (M2-smie-tests--indentations
+                    (concat "doc ///\n" prose "\n///\nf = (\na;\nb)\n"))
+                   '(0 0 0 0 4 4)))))
+
+(ert-deftest M2-smie-test-documentation-tab-can-indent ()
+  "TAB in a doc string steps one level further in, every time.
+Repeating the previous line's indentation instead would make TAB do
+nothing at all under a SimpleDoc key sitting at column 0, and aligning
+with that line reads badly in a language whose nesting is its meaning."
+  (with-temp-buffer
+    (insert "doc ///\nKey\n\n///\n")
+    (M2-mode)
+    (goto-char (point-min))
+    (forward-line 2)
+    (let ((this-command 'indent-for-tab-command))
+      (indent-according-to-mode))
+    ;; One step of `M2-simple-doc-indent-level' per press, cumulative.
+    (should (= (current-indentation) M2-simple-doc-indent-level))
+    (let ((this-command 'indent-for-tab-command))
+      (indent-according-to-mode))
+    (should (= (current-indentation) (* 2 M2-simple-doc-indent-level))))
+  ;; The same at the very end of the buffer, where a doc string being typed
+  ;; has no closing /// yet and there is no character to carry the property.
+  (with-temp-buffer
+    (insert "doc ///\nKey\n")
+    (M2-mode)
+    (goto-char (point-max))
+    (should (M2-inside-non-code-string-p (point)))
+    (let ((this-command 'indent-for-tab-command))
+      (indent-according-to-mode))
+    (should (= (current-indentation) 2)))
+  ;; ...and where the line above does offer something to line up with, it
+  ;; lines up with that rather than jumping to a tab stop.
+  (with-temp-buffer
+    (insert "doc ///\n  Description\nText\n///\n")
+    (M2-mode)
+    (goto-char (point-min))
+    (forward-line 2)
+    (let ((this-command 'indent-for-tab-command))
+      (indent-according-to-mode))
+    (should (= (current-indentation) 2))))
+
+(ert-deftest M2-smie-test-plain-raw-string-is-a-string ()
+  "A ///.../// with no recognized word in front of it is just a string."
+  (dolist (opener '("TEX" "lines"))
+    (let ((text (concat "s = " opener " ///\nraw ( data\n///\nf = (\na;\nb)\n")))
+      (should (nth 3 (with-temp-buffer
+                       (insert text) (M2-mode)
+                       (syntax-propertize (point-max))
+                       (syntax-ppss (- (point-max) 20)))))
+      (should (equal (M2-smie-tests--indentations text) '(0 0 0 0 4 4))))))
+
+(ert-deftest M2-smie-test-propertize-past-region-end ()
+  "Propertizing a region that a raw string runs past must not signal.
+`syntax-propertize' works in chunks, so a string routinely reaches beyond
+the region being handled; propertizing it carries point past the end."
+  (with-temp-buffer
+    (insert "s = TEX ///\n" (make-string 400 ?x) "\n///\nf = 1\n")
+    (M2-mode)
+    (should (progn (M2-syntax-propertize (point-min) 15) t))
+    (should (progn (M2-syntax-propertize (point-min) (point-max)) t))))
+
+(ert-deftest M2-smie-test-raw-string-escapes ()
+  "A run of slashes closes a raw string only when it is odd and at least 3.
+See the documentation of /// in Macaulay2: a run of four stands for a
+literal ///, and one of nine for /// followed by the terminator."
+  (dolist (literal '("///-- //// -- /////////"
+                     "///-- ////// -- ///////////"
+                     "//////////////"))
+    (should (equal (M2-smie-tests--indentations
+                    (concat "s = " literal "\nf = (\na;\nb)\n"))
+                   '(0 0 4 4)))))
+
+(ert-deftest M2-smie-test-triple-slash-lexes-atomically ()
+  "/// must lex as one token, not as the quotient operators // and /."
+  (with-temp-buffer
+    (insert "TEST ///\nx = 1\n///\n")
+    (M2-mode)
+    (goto-char (point-min))
+    (should (equal (M2-smie-forward-token) "TEST"))
+    (should (equal (M2-smie-forward-token) "///"))
+    (goto-char (point-max))
+    (M2-smie-backward-token)             ; the trailing newline
+    (should (equal (M2-smie-backward-token) "///"))))
+
+(ert-deftest M2-smie-test-indent-region-signals-nothing ()
+  "Indenting a buffer of assorted Macaulay2 constructs must not signal."
+  (with-temp-buffer
+    (insert "\
+needs \"foo.m2\"
+f = method(Options => {A => 1})
+f ZZ := o -> n -> (
+    if n < 0 then error \"negative\";
+    for i from 1 to n list (
+        g := i^2;
+        g));
+doc ///
+  Key
+    (f, ZZ)
+  Description
+    Text
+      prose with ( unbalanced brackets and a -- dash
+///
+")
+    (M2-mode)
+    (should-not (condition-case err
+                    (progn (indent-region (point-min) (point-max)) nil)
+                  (error err)))))
+
+(provide 'M2-smie-tests)
+
+;;; M2-smie-tests.el ends here

--- a/test/M2-smie-tests.el
+++ b/test/M2-smie-tests.el
@@ -495,11 +495,12 @@ nested strings, so this only works while the block itself is not one."
                     (concat "doc ///\n" prose "\n///\nf = (\na;\nb)\n"))
                    '(0 0 0 0 4 4)))))
 
-(ert-deftest M2-smie-test-documentation-tab-can-indent ()
-  "TAB in a doc string steps one level further in, every time.
-Repeating the previous line's indentation instead would make TAB do
-nothing at all under a SimpleDoc key sitting at column 0, and aligning
-with that line reads badly in a language whose nesting is its meaning."
+(ert-deftest M2-smie-test-documentation-tab-computes-a-column ()
+  "TAB in a doc string computes the column, and pressing it again does nothing.
+The engine in M2-simple-doc.el reads the structure of the SimpleDoc
+around the line, so there is nothing for a second press to add.  (It used
+to step one level further in each time, which was all a mode that did not
+understand the language could offer.)"
   (with-temp-buffer
     (insert "doc ///\nKey\n\n///\n")
     (M2-mode)
@@ -507,23 +508,23 @@ with that line reads badly in a language whose nesting is its meaning."
     (forward-line 2)
     (let ((this-command 'indent-for-tab-command))
       (indent-according-to-mode))
-    ;; One step of `M2-simple-doc-indent-level' per press, cumulative.
+    ;; The body of `Key', one fallback step in from it.
     (should (= (current-indentation) M2-simple-doc-indent-level))
     (let ((this-command 'indent-for-tab-command))
       (indent-according-to-mode))
-    (should (= (current-indentation) (* 2 M2-simple-doc-indent-level))))
+    (should (= (current-indentation) M2-simple-doc-indent-level)))
   ;; The same at the very end of the buffer, where a doc string being typed
   ;; has no closing /// yet and there is no character to carry the property.
   (with-temp-buffer
     (insert "doc ///\nKey\n")
     (M2-mode)
     (goto-char (point-max))
-    (should (M2-inside-non-code-string-p (point)))
+    (should (M2-inside-simple-doc-p (point)))
     (let ((this-command 'indent-for-tab-command))
       (indent-according-to-mode))
-    (should (= (current-indentation) 2)))
-  ;; ...and where the line above does offer something to line up with, it
-  ;; lines up with that rather than jumping to a tab stop.
+    (should (= (current-indentation) M2-simple-doc-indent-level)))
+  ;; A keyword goes where its table says it goes, however far off it starts:
+  ;; `Text' is legal only inside a `Description', so it lands in this one.
   (with-temp-buffer
     (insert "doc ///\n  Description\nText\n///\n")
     (M2-mode)
@@ -531,7 +532,7 @@ with that line reads badly in a language whose nesting is its meaning."
     (forward-line 2)
     (let ((this-command 'indent-for-tab-command))
       (indent-according-to-mode))
-    (should (= (current-indentation) 2))))
+    (should (= (current-indentation) (+ 2 M2-simple-doc-indent-level)))))
 
 (ert-deftest M2-smie-test-plain-raw-string-is-a-string ()
   "A ///.../// with no recognized word in front of it is just a string."


### PR DESCRIPTION
We add [SMIE](https://www.gnu.org/software/emacs/manual/html_node/elisp/SMIE.html) support for the M2 major modes.

Currently, the indentation behvavior is based entirely on paren depth:

```m2
f = x -> (
    if
    x
    then
    y
    else
    z)
```

With this change, Emacs now has some understanding of the syntax of the M2 language and knows to indent if we haven't finished the current statement:

```m2
f = x -> (
    if
        x
    then
        y
    else
        z)
```


### AI Disclosure

This was written almost entirely by Claude Code.

*Draft for now -- comments welcome!*