### PR TITLE
chg: exclude `--` in `<--` from being treated as comment delimiters

### DIFF
--- a/M2.el
+++ b/M2.el
@@ -193,7 +193,8 @@
   (setq font-lock-defaults '( M2-mode-font-lock-keywords ))
   (setq truncate-lines t)
   (setq case-fold-search nil)
-  (add-hook 'completion-at-point-functions #'M2-completion-at-point nil t))
+  (add-hook 'completion-at-point-functions #'M2-completion-at-point nil t)
+  (setq-local syntax-propertize-function (syntax-propertize-rules ("<\\(--\\)" (1 ".")))))
 
 ;; menus
 


### PR DESCRIPTION
Addresses https://github.com/Macaulay2/M2-emacs/issues/13 in the way described in the issue:

<img width="518" height="388" alt="Screenshot From 2026-05-18 01-48-50" src="https://github.com/user-attachments/assets/a19c1581-36cf-4fc1-a22a-8bd2ec9fb1fd" />

However, is this the best way to solve the issue (making `--` in `<--` never count as comment delimiter)?  Can there be any unforseen issues?