### PR TITLE
chg: deregister `--` as a comment delimiter, if we are in an output block

### DIFF
--- a/M2.el
+++ b/M2.el
@@ -181,6 +181,20 @@
 ; font-lock-doc-face
 ; font-lock-negation-char-face
 
+(defun M2--in-output-block-p (pos)
+  "Return non-nil if POS is inside an output block.
+This relies on `comint-mode` tagging output with the `field` text property."
+  (eq (get-text-property pos 'field) 'output))
+
+(defconst M2-syntax-propertize-function
+  (syntax-propertize-rules
+   ;; Make "--" act as punctuation (not a comment) in output blocks.
+   ("--"
+    (0 (let ((pos (match-beginning 0)))
+         (when (M2--in-output-block-p pos)
+           (string-to-syntax "."))))))
+  "Syntax propertize rules for Macaulay2 modes.")
+
 (defun M2-common ()
   "Set up features common to both Macaulay2 major modes."
   (set (make-local-variable 'comment-start) "-- ")
@@ -194,7 +208,7 @@
   (setq truncate-lines t)
   (setq case-fold-search nil)
   (add-hook 'completion-at-point-functions #'M2-completion-at-point nil t)
-  (setq-local syntax-propertize-function (syntax-propertize-rules ("<\\(--\\)" (1 ".")))))
+  (setq-local syntax-propertize-function M2-syntax-propertize-function))
 
 ;; menus
 


### PR DESCRIPTION
This supersedes the changes in https://github.com/Macaulay2/M2-emacs/commit/341d3c81f50fea1476865764570527b5d424c075.

The PR deregisters any `--` in an output block as comment delimiter.  In particular, the following should now be properly highlighted:

```
R = QQ[a,b,c,d]
I = ideal(a^2-b*c, a^3-b^3, a^4-b*d^3, a^5-c^2*d^3)
(res I).dd      -- note that arrows are normally coloured
1/314*a+1/271*b -- note that fraction bars are normally coloured
```

Screenshot:

<img width="1210" height="1632" alt="Screenshot From 2026-05-19 14-35-45" src="https://github.com/user-attachments/assets/44cc8117-077c-4883-996d-a7b0034f82c5" />
