### PR TITLE
Don't use tab characters to indent in M2-mode

### DIFF
--- a/M2.el
+++ b/M2.el
@@ -96,7 +96,8 @@
   "Major mode for editing Macaulay2 source code.
 
 \\\{M2-mode-map}."
-  (M2-common))
+  (M2-common)
+  (setq-local indent-tabs-mode nil))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.m2\\'" . M2-mode))


### PR DESCRIPTION
For consistency with the VS Code behavior.