### PR TITLE
Set compilation-error-screen-columns to nil in M2-comint-mode

### DIFF
--- a/M2.el
+++ b/M2.el
@@ -161,6 +161,7 @@
   (setq-local compilation-error-regexp-alist M2-error-regexp-alist)
   (setq-local compilation-transform-file-match-alist
 	      M2-transform-file-match-alist)
+  (setq-local compilation-error-screen-columns nil)
   (compilation-shell-minor-mode 1))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
This will make the "jump to source" feature interpret column numbers as number of characters and not screen width, e.g., tabs will count as 1.

Draft for now as some d code needs to be written to work with this.

Cc: @pzinn 